### PR TITLE
add text watermark

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,13 +601,13 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
           <dt>-vf "drawtext=fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2"</dt><dd>This calls the drawtext filters with the following options:
           <dl>
             <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
-            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this is proportional to video size, for example use ffprobe to acquire video height and divide by 12</dd>
+            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this value is proportional to video size, for example use ffprobe to acquire video height and divide by 14.</dd>
             <dt>text=<i>watermark_text</i> </dt><dd> Set the content of your watermark text. For example: <code>"text="FFMPROVISR HACK DAY NEVAR ENDS"</code></dd>
             <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>"fontcolor=white"</code> or a hexadecimal value such as <code>"fontcolor=0xFFFFFF"</code></dd>
             <dt>alpha=0.4</dt><dd> Set transparency value.</dd>
             <dt>x=w/2-tw/2:y=h/2-th/2</dt><dd> Sets <i>x</i> and <i>y</i> coordinates for the watermark. These relative values will centre your watermark regardless of video dimensions.</dd>
           </dl>
-          <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
+          <dt><i>output_file</i></dt><dd>path, name and extension of the output file.</dd>
         </dl>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -601,15 +601,12 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
           <dt>-vf "drawtext=fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2"</dt><dd>This calls the drawtext filters with the following options:
           <dl>
             <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
-            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this is proportional to video size, for example <code>videoheight/12</code></dd>
+            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this is proportional to video size, for example use ffprobe to acquire video height and divide by 12</dd>
             <dt>text=<i>watermark_text</i> </dt><dd> Set the content of your watermark text. For example: <code>"text="FFMPROVISR HACK DAY NEVAR ENDS"</code></dd>
-            <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>"fontcolor=white"</code> or a hexadecimal value such as <code>0xFFFFFF</code></dd>
-            <dt>alpha=0.4</dt><dd> Set transparency.</dd>
-            <dt>x=w/2-tw/2:y=h/2-th/2"</dt><dd> Sets <i>x</i> and <i>y</i> coordinates for the watermark. These relative values will centre your watermark regardless of video dimensions.</dd>
-         
+            <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>"fontcolor=white"</code> or a hexadecimal value such as <code>"fontcolor=0xFFFFFF"</code></dd>
+            <dt>alpha=0.4</dt><dd> Set transparency value.</dd>
+            <dt>x=w/2-tw/2:y=h/2-th/2</dt><dd> Sets <i>x</i> and <i>y</i> coordinates for the watermark. These relative values will centre your watermark regardless of video dimensions.</dd>
           </dl>
-
-          
           <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
         </dl>
       </div>

--- a/index.html
+++ b/index.html
@@ -592,7 +592,7 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
-        <h3>Create centered opaque text watermark</h3>
+        <h3>Create centered, transparent text watermark</h3>
         <p>E.g For creating access copies with your institutions name</p>
         <p><code>ffmpeg -i <i>input_file</i> -vf drawtext="fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2" <i>output_file</i></code></p>
         <dl>

--- a/index.html
+++ b/index.html
@@ -586,6 +586,33 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
   </div>
 </div>
 <!-- ends Modify speed -->
+<!-- Text Watermark -->
+<span data-toggle="modal" data-target=".text_watermark"><button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Create opaque centered text watermark ">Text Watermark</button></span>
+<div class="modal fade text_watermark" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>Created centered opaque text watermark</h3>
+        <p>E.g For creating access copies with your institutions name</p>
+        <p><code>ffmpeg -i <i>input_file</i> -vf drawtext="fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2" <i>output_file</i></code></p>
+        <dl>
+          <dt>ffmpeg</dt><dd>starts the command</dd>
+          <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+          <dt>-vf "drawtext=fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2"</dt><dd>This calls the drawtext filters with the following options:
+          <dl>
+            <dt>In the video filter <code>setpts</code> the numerator <code>input_fps</code> sets the input speed and the denominator <code>output_fps</code> sets the output speed; both values are given in frames per second.</dt>
+            <dt>In the sound filter <code>atempo</code> the numerator <code>output_fps</code> sets the output speed and the denominator <code>input_fps</code> sets the input speed; both values are given in frames per second.</dt>
+          </dl>
+          The different filters in a complex filter can be divided either by comma or semicolon. The quotation marks allow to insert a space between the filters for readability.</dd>
+          <dt>-map "[v]"</dt><dd>maps the video stream and:</dd>
+          <dt>-map "[a]"</dt><dd>maps the audio stream together into:</dd>
+          <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- ends Text watermark -->
 
 </div> <!-- end "well col-md-6 col-md-offset-2" -->
 </div> <!-- row -->

--- a/index.html
+++ b/index.html
@@ -602,11 +602,14 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
           <dl>
             <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
             <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this is proportional to video size, for example <code>videoheight/12</code></dd>
-            <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
+            <dt>text=<i>watermark_text</i> </dt><dd> Set the content of your watermark text. For example: <code>"text="FFMPROVISR HACK DAY NEVAR ENDS"</code></dd>
+            <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>"fontcolor=white"</code> or a hexadecimal value such as <code>0xFFFFFF</code></dd>
+            <dt>alpha=0.4</dt><dd> Set transparency.</dd>
+            <dt>x=w/2-tw/2:y=h/2-th/2"</dt><dd> Sets <i>x</i> and <i>y</i> coordinates for the watermark. These relative values will centre your watermark regardless of video dimensions.</dd>
+         
           </dl>
 
-          <dt>-map "[v]"</dt><dd>maps the video stream and:</dd>
-          <dt>-map "[a]"</dt><dd>maps the audio stream together into:</dd>
+          
           <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
         </dl>
       </div>

--- a/index.html
+++ b/index.html
@@ -604,7 +604,7 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
             <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this is proportional to video size, for example <code>videoheight/12</code></dd>
             <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
           </dl>
-          The different filters in a complex filter can be divided either by comma or semicolon. The quotation marks allow to insert a space between the filters for readability.</dd>
+
           <dt>-map "[v]"</dt><dd>maps the video stream and:</dd>
           <dt>-map "[a]"</dt><dd>maps the audio stream together into:</dd>
           <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>

--- a/index.html
+++ b/index.html
@@ -600,8 +600,8 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
           <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
           <dt>-vf "drawtext=fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2"</dt><dd>This calls the drawtext filters with the following options:
           <dl>
-            <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
-            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this value is proportional to video size, for example use ffprobe to acquire video height and divide by 14.</dd>
+            <dt>fontfile=<i>font_path</i></dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
+            <dt>fontsize=<i>font_size</i></dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this value is proportional to video size, for example use ffprobe to acquire video height and divide by 14.</dd>
             <dt>text=<i>watermark_text</i> </dt><dd> Set the content of your watermark text. For example: <code>"text="FFMPROVISR HACK DAY NEVAR ENDS"</code></dd>
             <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>"fontcolor=white"</code> or a hexadecimal value such as <code>"fontcolor=0xFFFFFF"</code></dd>
             <dt>alpha=0.4</dt><dd> Set transparency value.</dd>

--- a/index.html
+++ b/index.html
@@ -594,18 +594,18 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
       <div class="well">
         <h3>Create centered, transparent text watermark</h3>
         <p>E.g For creating access copies with your institutions name</p>
-        <p><code>ffmpeg -i <i>input_file</i> -vf drawtext="fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2" <i>output_file</i></code></p>
+        <p><code>ffmpeg -i <i>input_file</i> -vf drawtext="fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=(w-text_w)/2:y=(h-text_h)/2" <i>output_file</i></code></p>
         <dl>
           <dt>ffmpeg</dt><dd>starts the command</dd>
           <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
           <dt>-vf drawtext=</dt><dd>This calls the drawtext filters with the following options:
           <dl>
-            <dt>fontfile=<i>font_path</i></dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
+            <dt>fontfile=<i>font_path</i></dt><dd> Set path to font. For example in OSX: <code>fontfile=/Library/Fonts/AppleGothic.ttf</code></dd>
             <dt>fontsize=<i>font_size</i></dt><dd> Set font size. <code>35</code> is a good starting point for SD. Ideally this value is proportional to video size, for example use ffprobe to acquire video height and divide by 14.</dd>
-            <dt>text=<i>watermark_text</i> </dt><dd> Set the content of your watermark text. For example: <code>"text="FFMPROVISR HACK DAY NEVAR ENDS"</code></dd>
-            <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>"fontcolor=white"</code> or a hexadecimal value such as <code>"fontcolor=0xFFFFFF"</code></dd>
+            <dt>text=<i>watermark_text</i> </dt><dd> Set the content of your watermark text. For example: <code>text='FFMPROVISR HACK DAY NEVAR ENDS'</code></dd>
+            <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>fontcolor=white</code> or a hexadecimal value such as <code>fontcolor=0xFFFFFF</code></dd>
             <dt>alpha=0.4</dt><dd> Set transparency value.</dd>
-            <dt>x=w/2-tw/2:y=h/2-th/2</dt><dd> Sets <i>x</i> and <i>y</i> coordinates for the watermark. These relative values will centre your watermark regardless of video dimensions.</dd>
+            <dt>x=(w-text_w)/2:y=(h-text_h)/2</dt><dd> Sets <i>x</i> and <i>y</i> coordinates for the watermark. These relative values will centre your watermark regardless of video dimensions.</dd>
           </dl>
           <dt><i>output_file</i></dt><dd>path, name and extension of the output file.</dd>
         </dl>

--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
         <dl>
           <dt>ffmpeg</dt><dd>starts the command</dd>
           <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-          <dt>-vf "drawtext=fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2"</dt><dd>This calls the drawtext filters with the following options:
+          <dt>-vf drawtext=</dt><dd>This calls the drawtext filters with the following options:
           <dl>
             <dt>fontfile=<i>font_path</i></dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
             <dt>fontsize=<i>font_size</i></dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this value is proportional to video size, for example use ffprobe to acquire video height and divide by 14.</dd>

--- a/index.html
+++ b/index.html
@@ -592,7 +592,7 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
-        <h3>Created centered opaque text watermark</h3>
+        <h3>Create centered opaque text watermark</h3>
         <p>E.g For creating access copies with your institutions name</p>
         <p><code>ffmpeg -i <i>input_file</i> -vf drawtext="fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2" <i>output_file</i></code></p>
         <dl>
@@ -600,8 +600,9 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
           <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
           <dt>-vf "drawtext=fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2"</dt><dd>This calls the drawtext filters with the following options:
           <dl>
-            <dt>In the video filter <code>setpts</code> the numerator <code>input_fps</code> sets the input speed and the denominator <code>output_fps</code> sets the output speed; both values are given in frames per second.</dt>
-            <dt>In the sound filter <code>atempo</code> the numerator <code>output_fps</code> sets the output speed and the denominator <code>input_fps</code> sets the input speed; both values are given in frames per second.</dt>
+            <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
+            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24 is a good value for SD. Ideally this is proportional to video size, for example <code>videoheight/12</code></dd>
+            <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
           </dl>
           The different filters in a complex filter can be divided either by comma or semicolon. The quotation marks allow to insert a space between the filters for readability.</dd>
           <dt>-map "[v]"</dt><dd>maps the video stream and:</dd>

--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
           <dt>-vf "drawtext=fontfile=<i>font_path</i>:fontsize=<i>font_size</i>:text=<i>watermark_text</i>:fontcolor=<i>font_colour</i>:alpha=0.4:x=w/2-tw/2:y=h/2-th/2"</dt><dd>This calls the drawtext filters with the following options:
           <dl>
             <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
-            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24 is a good value for SD. Ideally this is proportional to video size, for example <code>videoheight/12</code></dd>
+            <dt>fontsize=<i>font_size </dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this is proportional to video size, for example <code>videoheight/12</code></dd>
             <dt>fontfile=<i>font_path </dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
           </dl>
           The different filters in a complex filter can be divided either by comma or semicolon. The quotation marks allow to insert a space between the filters for readability.</dd>

--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@ path_name_and_extension_to_the_last_file</i></pre></dd>
           <dt>-vf drawtext=</dt><dd>This calls the drawtext filters with the following options:
           <dl>
             <dt>fontfile=<i>font_path</i></dt><dd> Set path to font. For example in OSX: <code>"fontfile=/Library/Fonts/AppleGothic.ttf"</code></dd>
-            <dt>fontsize=<i>font_size</i></dt><dd> Set font size. <code>24</code> is a good value for SD. Ideally this value is proportional to video size, for example use ffprobe to acquire video height and divide by 14.</dd>
+            <dt>fontsize=<i>font_size</i></dt><dd> Set font size. <code>35</code> is a good starting point for SD. Ideally this value is proportional to video size, for example use ffprobe to acquire video height and divide by 14.</dd>
             <dt>text=<i>watermark_text</i> </dt><dd> Set the content of your watermark text. For example: <code>"text="FFMPROVISR HACK DAY NEVAR ENDS"</code></dd>
             <dt>fontcolor=<i>font_colour</i> </dt><dd> Set colour of font. Can be a text string such as <code>"fontcolor=white"</code> or a hexadecimal value such as <code>"fontcolor=0xFFFFFF"</code></dd>
             <dt>alpha=0.4</dt><dd> Set transparency value.</dd>


### PR DESCRIPTION
Hopefully the -vf description doesn't break any style constraints. Haven't properly used html since geocities.
From what I can tell, fontsize only accepts an integer, so any relative value must be generated via scripts. Please let me know if there's another way, similar to the x/y placement.
