### PR TITLE
Script to open ffmprovisr when installed via homebrew

### DIFF
--- a/scripts/ffmprovisr
+++ b/scripts/ffmprovisr
@@ -9,3 +9,13 @@ if [[ $OSTYPE = darwin* ]] ; then
     fi
     open "${ffmprovisr_path}"
 fi
+
+if [[ $OSTYPE = linux-gnu ]] ; then
+    if [ -d ~/.linuxbrew/Cellar/ffmprovisr ] ; then
+		ffmprovisr_path=$(find ~/.linuxbrew/Cellar/ffmprovisr -iname 'index.html' | sort -M | tail -n1)
+    fi
+    if [ -z "${ffmprovisr_path}" ] ; then
+       		ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'
+    fi
+    xdg-open "${ffmprovisr_path}"
+fi

--- a/scripts/ffmprovisr
+++ b/scripts/ffmprovisr
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $OSTYPE = darwin* ]] ; then
+    if [ -d /usr/local/Cellar/ffmprovisr ] ; then
+        ffmprovisr_path=$(find /usr/local/Cellar/ffmprovisr -iname 'index.html' | sort -M | tail -n1)
+    fi
+    if [ -z "${ffmprovisr_path}" ] ; then
+        ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'
+    fi
+    open "${ffmprovisr_path}"
+fi

--- a/scripts/ffmprovisr
+++ b/scripts/ffmprovisr
@@ -8,8 +8,7 @@ if [[ $OSTYPE = darwin* ]] ; then
         ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'
     fi
     open "${ffmprovisr_path}"
-elif
- [[ $OSTYPE = linux-gnu ]] ; then
+elif [[ $OSTYPE = linux-gnu ]] ; then
     if [ -d ~/.linuxbrew/Cellar/ffmprovisr ] ; then
         ffmprovisr_path=$(find ~/.linuxbrew/Cellar/ffmprovisr -iname 'index.html' | sort -M | tail -n1)
     fi

--- a/scripts/ffmprovisr
+++ b/scripts/ffmprovisr
@@ -12,10 +12,10 @@ fi
 
 if [[ $OSTYPE = linux-gnu ]] ; then
     if [ -d ~/.linuxbrew/Cellar/ffmprovisr ] ; then
-		ffmprovisr_path=$(find ~/.linuxbrew/Cellar/ffmprovisr -iname 'index.html' | sort -M | tail -n1)
+        ffmprovisr_path=$(find ~/.linuxbrew/Cellar/ffmprovisr -iname 'index.html' | sort -M | tail -n1)
     fi
     if [ -z "${ffmprovisr_path}" ] ; then
-       		ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'
+        ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'
     fi
     xdg-open "${ffmprovisr_path}"
 fi

--- a/scripts/ffmprovisr
+++ b/scripts/ffmprovisr
@@ -8,9 +8,8 @@ if [[ $OSTYPE = darwin* ]] ; then
         ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'
     fi
     open "${ffmprovisr_path}"
-fi
-
-if [[ $OSTYPE = linux-gnu ]] ; then
+elif
+ [[ $OSTYPE = linux-gnu ]] ; then
     if [ -d ~/.linuxbrew/Cellar/ffmprovisr ] ; then
         ffmprovisr_path=$(find ~/.linuxbrew/Cellar/ffmprovisr -iname 'index.html' | sort -M | tail -n1)
     fi


### PR DESCRIPTION
To partially address https://github.com/amiaopensource/ffmprovisr/issues/150 I made a homebrew formula at https://github.com/amiaopensource/homebrew-amiaos/blob/ffmprovisr/ffmprovisr.rb.

This simple script would provide an easy shortcut to open the local ffmprovisr install via terminal.  Only supports homebrew/macOS but would be easy to add in a path for linuxbrew.

If this is merged/new release made then the brew formula could be updated and merged (currently would error since this script doesn't exist in the most recent release).

* revised to remove apology as per https://github.com/amiaopensource/ffmprovisr/issues/182