### PR TITLE
sets wordbreak in firefox for long code

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -4,6 +4,7 @@ h1, h2, h3, h4, h5, h6 {
 
 code {
   word-break: break-all;
+  word-wrap: break-word;
 }
 
 dd {


### PR DESCRIPTION
@privatezero noticed this problem, this additional line should correct it.