### PR TITLE
batch processing mac/linux: adds find command - for #207

### DIFF
--- a/index.html
+++ b/index.html
@@ -1267,7 +1267,7 @@
           <p>The basic pattern will look similar to this:<br>
           <code>for item in *.ext; do ffmpeg -i $item <i>(ffmpeg options here)</i> "${item%.ext}_suffix.ext"</code></p>
           <p>e.g., if an input file is bestmovie002.avi, its output will be bestmovie002_suffix.avi.</p>
-          <p>Variation: recursively process all mxf files in subdirectories using <code>find</code> instead of <code>for</code>:</p>
+          <p>Variation: recursively process all MXF files in subdirectories using <code>find</code> instead of <code>for</code>:</p>
           <p><code>find input_directory -iname "*.mxf" -exec ffmpeg -i {} -map 0 -c copy {}.mov \;</code></p>
           <p class="link"></p>
         </div>

--- a/index.html
+++ b/index.html
@@ -1267,6 +1267,8 @@
           <p>The basic pattern will look similar to this:<br>
           <code>for item in *.ext; do ffmpeg -i $item <i>(ffmpeg options here)</i> "${item%.ext}_suffix.ext"</code></p>
           <p>e.g., if an input file is bestmovie002.avi, its output will be bestmovie002_suffix.avi.</p>
+          <p>Variation: recursively process all mxf files in subdirectories using <code>find</code> instead of <code>for</code>:</p>
+          <p><code>find input_directory -iname "*.mxf" -exec ffmpeg -i {} -map 0 -c copy {}.mov \;</code></p>
           <p class="link"></p>
         </div>
       </div>


### PR DESCRIPTION
Hi all,

I thought I'd take a stab at this. Looking from the comments in #207, I thought that it might be overkill to do a full, command by command breakdown of `find`, so I just threw in a one-liner. I already did something like this over here so I could just reuse some of this if needed: https://github.com/kieranjol/ifi_batch_workshop#recursive-loop-search-through-all-subfolders

Also, I couldn't figure out how to remove the .mov extension while using `find`. It could be done by piping the output of find to a for loop, but I thought this kept things a lot simpler.

Let me know what ye think anyhow,