### PR TITLE
add note about dither methods to the audio recipes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,14 +324,18 @@
           <dl>
             <dt>ffmpeg</dt><dd>starts the command</dd>
             <dt>-i <i>input_file</i></dt><dd>path and name of the input file</dd>
-            <dt>-write_id3v1 <i>1</i></dt><dd>Write ID3v1 tag. This will add metadata to the "older" MP3 metadata format that's found at the head of the file, assuming you’ve embedded metadata into the WAV file.</dd>
-            <dt>-id3v2_version <i>3</i></dt><dd>Write ID3v2 tag. This will add metadata to the "newer" MP3 metadata format that's found at the tail of the file, assuming you’ve embedded metadata into the WAV file.</dd>
+            <dt>-write_id3v1 <i>1</i></dt><dd>This will write metadata to an ID3v1 tag at the head of the file, assuming you’ve embedded metadata into the WAV file.</dd>
+            <dt>-id3v2_version <i>3</i></dt><dd>This will write metadata to an ID3v2.3 tag at the tail of the file, assuming you’ve embedded metadata into the WAV file.</dd>
             <dt>-dither_method <i>rectangular</i></dt><dd>Dither makes sure you don’t unnecessarily truncate the dynamic range of your audio.</dd>
             <dt>-out_sample_rate <i>48k</i></dt><dd>Sets the audio sampling frequency to 48 kHz. This can be omitted to use the same sampling frequency as the input.</dd>
             <dt>-qscale:a <i>1</i></dt><dd>This sets the encoder to use a constant quality with a variable bitrate of between 190-250kbit/s. If you would prefer to use a constant bitrate, this could be replaced with <code>-b:a 320k</code> to set to the maximum bitrate allowed by the MP3 format. For more detailed discussion on variable vs constant bitrates see <a href="https://trac.ffmpeg.org/wiki/Encode/MP3" target="_blank">here.</a></dd>
             <dt><i>output_file</i></dt><dd>path and name of the output file</dd>
           </dl>
-          <p>A note about dither methods. FFMPEG comes with a variety of dither algorithms, outlined in the <a href="https://ffmpeg.org/ffmpeg-resampler.html" target="_blank" rel="noopener noreferrer">official docs</a>, though some may lead to unintended, not-subtle digital clipping on some systems.</p>
+          <p>A couple notes<p>
+            <ul>
+              <li>About ID3v2.3 tag: ID3v2.3 is better supported than ID3v2.4, FFmpeg's default ID3v2 setting.<li>
+              <li>About dither methods: FFmpeg comes with a variety of dither algorithms, outlined in the <a href="https://ffmpeg.org/ffmpeg-resampler.html" target="_blank" rel="noopener noreferrer">official docs</a>, though some may lead to unintended, drastic digital clipping on some systems.</li>
+            </ul>
           <p class="link"></p>
         </div>
       </div>
@@ -357,7 +361,7 @@
             <dt>-ar 44100</dt><dd>sets the audio sampling frequency to 44100 Hz, or 44.1 kHz, or “CD quality”</dd>
             <dt><i>output_file</i></dt><dd>path and name of the output file</dd>
           </dl>
-          <p>A note about dither methods. FFMPEG comes with a variety of dither algorithms, outlined in the <a href="https://ffmpeg.org/ffmpeg-resampler.html" target="_blank" rel="noopener noreferrer">official docs</a>, though some may lead to unintended, not-subtle digital clipping on some systems.</p>
+          <p>A note about dither methods. FFmpeg comes with a variety of dither algorithms, outlined in the <a href="https://ffmpeg.org/ffmpeg-resampler.html" target="_blank" rel="noopener noreferrer">official docs</a>, though some may lead to unintended, not-subtle digital clipping on some systems.</p>
           <p class="link"></p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -324,13 +324,14 @@
           <dl>
             <dt>ffmpeg</dt><dd>starts the command</dd>
             <dt>-i <i>input_file</i></dt><dd>path and name of the input file</dd>
-            <dt>-write_id3v1 <i>1</i></dt><dd>Write ID3v1 tag. This will add metadata to the old MP3 format, assuming you’ve embedded metadata into the WAV file.</dd>
-            <dt>-id3v2_version <i>3</i></dt><dd>Write ID3v2 tag. This will add metadata to a newer MP3 format, assuming you’ve embedded metadata into the WAV file.</dd>
-            <dt>-dither_method <i>modified_e_weighted</i></dt><dd>Dither makes sure you don’t unnecessarily truncate the dynamic range of your audio.</dd>
+            <dt>-write_id3v1 <i>1</i></dt><dd>Write ID3v1 tag. This will add metadata to the "older" MP3 metadata format that's found at the head of the file, assuming you’ve embedded metadata into the WAV file.</dd>
+            <dt>-id3v2_version <i>3</i></dt><dd>Write ID3v2 tag. This will add metadata to the "newer" MP3 metadata format that's found at the tail of the file, assuming you’ve embedded metadata into the WAV file.</dd>
+            <dt>-dither_method <i>rectangular</i></dt><dd>Dither makes sure you don’t unnecessarily truncate the dynamic range of your audio.</dd>
             <dt>-out_sample_rate <i>48k</i></dt><dd>Sets the audio sampling frequency to 48 kHz. This can be omitted to use the same sampling frequency as the input.</dd>
             <dt>-qscale:a <i>1</i></dt><dd>This sets the encoder to use a constant quality with a variable bitrate of between 190-250kbit/s. If you would prefer to use a constant bitrate, this could be replaced with <code>-b:a 320k</code> to set to the maximum bitrate allowed by the MP3 format. For more detailed discussion on variable vs constant bitrates see <a href="https://trac.ffmpeg.org/wiki/Encode/MP3" target="_blank">here.</a></dd>
             <dt><i>output_file</i></dt><dd>path and name of the output file</dd>
           </dl>
+          <p>A note about dither methods. FFMPEG comes with a variety of dither algorithms, outlined in the <a href="https://ffmpeg.org/ffmpeg-resampler.html" target="_blank" rel="noopener noreferrer">official docs</a>, though some may lead to unintended, not-subtle digital clipping on some systems.</p>
           <p class="link"></p>
         </div>
       </div>
@@ -352,10 +353,11 @@
             <dt>-i <i>input_file</i></dt><dd>path and name of the input file</dd>
             <dt>-c:a aac</dt><dd>sets the audio codec to AAC</dd>
             <dt>-b:a 128k</dt><dd>sets the bitrate of the audio to 128k</dd>
-            <dt>-dither_method modified_e_weighted</dt><dd>Dither makes sure you don’t unnecessarily truncate the dynamic range of your audio.</dd>
+            <dt>-dither_method rectangular</dt><dd>Dither makes sure you don’t unnecessarily truncate the dynamic range of your audio.</dd>
             <dt>-ar 44100</dt><dd>sets the audio sampling frequency to 44100 Hz, or 44.1 kHz, or “CD quality”</dd>
             <dt><i>output_file</i></dt><dd>path and name of the output file</dd>
           </dl>
+          <p>A note about dither methods. FFMPEG comes with a variety of dither algorithms, outlined in the <a href="https://ffmpeg.org/ffmpeg-resampler.html" target="_blank" rel="noopener noreferrer">official docs</a>, though some may lead to unintended, not-subtle digital clipping on some systems.</p>
           <p class="link"></p>
         </div>
       </div>


### PR DESCRIPTION
Recently, I noticed a strange pheonomenon with the previous dither method where the FFMPEG resampler would greatly increase the gain.

Also, I redid some of the explanations about the metadata formats.