### PR TITLE
shortens button names

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,12 +24,12 @@
     <p class="link"></p>
     <p class="select-from">Click one of the following categories to see commands of that type:</p>
     <a href="#about"><button type="button" class="btn contents-list">About this resource</button></a>
-    <a href="#basics"><button type="button" class="btn contents-list">Learn about FFmpeg basics</button></a>
-    <a href="#concepts"><button type="button" class="btn contents-list">Learn about more advanced FFmpeg concepts</button></a>
+    <a href="#basics"><button type="button" class="btn contents-list">FFmpeg basics</button></a>
+    <a href="#concepts"><button type="button" class="btn contents-list">Advanced FFmpeg concepts</button></a>
     <a href="#rewrap"><button type="button" class="btn contents-list">Change container (rewrap)</button></a>
     <a href="#transcode"><button type="button" class="btn contents-list">Change codec (transcode)</button></a>
     <a href="#properties"><button type="button" class="btn contents-list">Change video properties</button></a>
-    <a href="#join-trim"><button type="button" class="btn contents-list">Join videos, or trim/create an excerpt from a video</button></a>
+    <a href="#join-trim"><button type="button" class="btn contents-list">Join/trim/create an excerpt</button></a>
     <a href="#interlacing"><button type="button" class="btn contents-list">Work with interlaced video</button></a>
     <a href="#filters-scopes"><button type="button" class="btn contents-list">Use filters or scopes</button></a>
     <a href="#metadata"><button type="button" class="btn contents-list">View or strip metadata</button></a>
@@ -1856,7 +1856,7 @@ ffmpeg -i $file -map 0 -c copy $output
   <!-- ends Combine audio tracks  -->
 
   <!-- append notice to access mp3 -->
-  <span data-toggle="collapse" data-target="#append_mp3"><button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Generate two access MP3s from input. One with added audio (such as a copyright notice) and one unmodified.">Create access MP3 (+ access MP3 with copyright notice)</button></span>
+  <span data-toggle="collapse" data-target="#append_mp3"><button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Generate two access MP3s from input. One with added audio (such as a copyright notice) and one unmodified.">Create access MP3</button></span>
   <div id="append_mp3" class="collapse" tabindex="-1" role="dialog">
     <h3>Generate two access MP3s from input. One with appended audio (such as a copyright notice) and one unmodified.</h3>
     <p class="link"></p>


### PR DESCRIPTION
This should help Ben's issue in #235, also a similar issue I had with ffmprovisr not listening to the viewport width on small/mobile devices, making it hard to use. It's not perfect yet, but I will work on the buttons overall next, which will make the problem go away (and text can just overflow naturally).