### PR TITLE
More page reorg: thumbnails/GIFs, audio recipes

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
     <a href="#metadata"><div class="contents-list">View or strip metadata</div></a>
     <a href="#preservation"><div class="contents-list">Preservation tasks</div></a>
     <a href="#test-files"><div class="contents-list">Generate test files</div></a>
-    <a href="#repair"><div class="contents-list">Repair a file</div></a>
     <a href="#ocr"><div class="contents-list">Use OCR</div></a>
     <a href="#perceptual-similarity"><div class="contents-list">Compare similarity of videos</div></a>
     <a href="#other"><div class="contents-list">Something else</div></a>
@@ -750,6 +749,23 @@
     </dl>
   </div>
   <!-- ends two pass loudnorm -->
+
+  <!-- Fix A/V async 1 -->
+  <span data-toggle="collapse" data-target="#avsync_aresample"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Fix A/V sync issues by resampling audio">Fix AV Sync: Resample audio</button></span>
+  <div id="avsync_aresample" class="collapse">
+    <h3>Fix AV Sync: Resample audio</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -c:v copy -c:a pcm_s16le -af "aresample=async=1000" <i>output_file</i></code></p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-c:v copy</dt><dd>Copy all mapped video streams.</dd>
+      <dt>-c:a pcm_s16le</dt><dd>tells FFmpeg to encode the audio stream in 16-bit linear PCM (<a href="https://en.wikipedia.org/wiki/Endianness#Little-endian" target="_blank">little endian</a>)</dd>
+      <dt>-af "aresample=async=1000"</dt><dd>Uses the <a href="https://ffmpeg.org/ffmpeg-filters.html#aresample-1" target="_blank">aresample</a> filter to stretch/squeeze samples to given timestamps, with a maximum of 1000 samples per second compensation.</dd>
+      <dt><i>output_file</i></dt><dd>path, name and extension of the output file. Try different file extensions such as mkv, mov, mp4, or avi.</dd>
+    </dl>
+  </div>
+  <!-- ends Fix A/V async 1 -->
 
   </div>
   <div class="well">
@@ -1725,27 +1741,6 @@ ffmpeg -i $file -map 0 -c copy $output
     </dl>
   </div>
   <!-- ends Broken File -->
-
-  </div>
-  <div class="well">
-  <h2 id="repair">Repair</h2>
-
-  <!-- Fix A/V async 1 -->
-  <span data-toggle="collapse" data-target="#avsync_aresample"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Fix A/V sync issues by resampling audio">Fix AV Sync: Resample audio</button></span>
-  <div id="avsync_aresample" class="collapse">
-    <h3>Fix AV Sync: Resample audio</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -c:v copy -c:a pcm_s16le -af "aresample=async=1000" <i>output_file</i></code></p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-c:v copy</dt><dd>Copy all mapped video streams.</dd>
-      <dt>-c:a pcm_s16le</dt><dd>tells FFmpeg to encode the audio stream in 16-bit linear PCM (<a href="https://en.wikipedia.org/wiki/Endianness#Little-endian" target="_blank">little endian</a>)</dd>
-      <dt>-af "aresample=async=1000"</dt><dd>Uses the <a href="https://ffmpeg.org/ffmpeg-filters.html#aresample-1" target="_blank">aresample</a> filter to stretch/squeeze samples to given timestamps, with a maximum of 1000 samples per second compensation.</dd>
-      <dt><i>output_file</i></dt><dd>path, name and extension of the output file. Try different file extensions such as mkv, mov, mp4, or avi.</dd>
-    </dl>
-  </div>
-  <!-- ends Fix A/V async 1 -->
 
   </div>
   <div class="well">

--- a/index.html
+++ b/index.html
@@ -27,15 +27,14 @@
     <a href="#concepts"><div class="contents-list">Advanced FFmpeg concepts</div></a>
     <a href="#rewrap"><div class="contents-list">Change container (rewrap)</div></a>
     <a href="#transcode"><div class="contents-list">Change codec (transcode)</div></a>
-    <a href="#properties"><div class="contents-list">Change video properties</div></a>
+    <a href="#video-properties"><div class="contents-list">Change video properties</div></a>
+    <a href="#audio-files"><div class="contents-list">Change or view audio properties</div></a>
     <a href="#join-trim"><div class="contents-list">Join/trim/create an excerpt</div></a>
     <a href="#interlacing"><div class="contents-list">Work with interlaced video</div></a>
     <a href="#overlay"><div class="contents-list">Overlay timecode or text on a video</div></a>
-    <a href="#create-thumbnails"><div class="contents-list">Generate image files from a video</div></a>
-    <a href="#animated-gif"><div class="contents-list">Generate an animated GIF</div></a>
+    <a href="#create-images"><div class="contents-list">Create thumbnails or GIFs</div></a>
     <a href="#create-video"><div class="contents-list">Create a video from image(s) and audio</div></a>
     <a href="#filters-scopes"><div class="contents-list">Use filters or scopes</div></a>
-    <a href="#normalise-audio"><div class="contents-list">Normalize/equalize audio</div></a>
     <a href="#metadata"><div class="contents-list">View or strip metadata</div></a>
     <a href="#preservation"><div class="contents-list">Preservation tasks</div></a>
     <a href="#test-files"><div class="contents-list">Generate test files</div></a>
@@ -374,6 +373,31 @@
   </div>
   <!-- ends WAV to MP3 -->
 
+  <!-- append notice to access mp3 -->
+  <span data-toggle="collapse" data-target="#append_mp3"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Generate two access MP3s from input. One with added audio (such as a copyright notice) and one unmodified.">Create access MP3</button></span>
+  <div id="append_mp3" class="collapse">
+    <h3>Generate two access MP3s from input. One with appended audio (such as a copyright notice) and one unmodified.</h3>
+    <p class="link"></p>
+    <p> <code>ffmpeg -i <i>input_file</i> -i <i>input_file_to_append</i> -filter_complex "[0:a:0]asplit=2[a][b];[b]afifo[bb];[1:a:0][bb]concat=n=2:v=0:a=1[concatout]" -map "[a]" -codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2 <i>output_file.mp3</i> -map "[concatout]" -codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2 <i>output_file_appended.mp3</i></code></p>
+    <p>This script allows you to generate two derivative audio files from a master while appending audio from a separate file (for example a copyright or institutional notice) to one of them.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file (the master file)</dd>
+      <dt>-i <i>input_file_to_append</i></dt><dd>path, name and extension of the input file (the file to be appended to access file)</dd>
+      <dt>-filter_complex</dt><dd>enables the complex filtering to manage splitting the input to two audio streams</dd>
+      <dt>[0:a:0]asplit=2[a][b];</dt><dd><code>asplit</code> allows audio streams to be split up for separate manipulation. This command splits the audio from the first input (the master file) into two streams "a" and "b"</dd>
+      <dt>[b]afifo[bb];</dt><dd>this buffers the stream "b" to help prevent dropped samples and renames stream to "bb"</dd>
+      <dt>[1:a:0][bb]concat=n=2:v=0:a=1[concatout]</dt><dd><code>concat</code> is used to join files. <code>n=2</code> tells the filter there are two inputs. <code>v=0:a=1</code> Tells the filter there are 0 video outputs and 1 audio output. This command appends the audio from the second input to the beginning of stream "bb" and names the output "concatout"</dd>
+      <dt>-map "[a]"</dt><dd>this maps the unmodified audio stream to the first output</dd>
+      <dt>-codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2</dt><dd>sets up MP3 options (using constant quality)</dd>
+      <dt><i>output_file</i></dt><dd>path, name and extension of the output file (unmodified)</dd>
+      <dt>-map "[concatout]"</dt><dd>this maps the modified stream to the second output</dd>
+      <dt>-codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2</dt><dd>sets up MP3 options (using constant quality)</dd>
+      <dt><i>output_file_appended</i></dt><dd>path, name and extension of the output file (with appended notice)</dd>
+    </dl>
+  </div>
+  <!-- ends append notice to access mp3 -->
+
   <!-- WAV to AAC/MP4 -->
   <span data-toggle="collapse" data-target="#wav_to_mp4"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Convert WAV to AAC/MP4">WAV to AAC/MP4</button></span>
   <div id="wav_to_mp4" class="collapse">
@@ -396,7 +420,7 @@
 
   </div>
   <div class="well">
-  <h2 id="properties">Change video properties</h2>
+  <h2 id="video-properties">Change video properties</h2>
 
   <!-- 4:3 to 16:9 -->
   <span data-toggle="collapse" data-target="#SD_HD"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Transform 4:3 aspect ratio into 16:9 with pillarbox">4:3 to 16:9</button></span>
@@ -585,6 +609,147 @@
     <p>The possible values for <code>-color_primaries</code>, <code>-color_trc</code>, and <code>-field_order</code> are given in the <a href="http://ffmpeg.org/ffmpeg-all.html#toc-Codec-Options" target="_blank">Codec Options</a> section of the FFmpeg docs - scroll down to near the bottom of the section.</p>
   </div>
   <!-- ends Make stream properties explicate -->
+
+  </div>
+  <div class="well">
+  <h2 id="audio-files">Change or view audio properties</h2>
+
+  <!-- Extract audio from an AV file -->
+  <span data-toggle="collapse" data-target="#extract_audio"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Extract audio without loss from an AV file">Extract audio</button></span>
+  <div id="extract_audio" class="collapse">
+    <h3>Extract audio from an AV file</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -c:a copy -vn <i>output_file</i></code></p>
+    <p>This command extracts the audio stream without loss from an audiovisual file.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-c:a copy</dt><dd>re-encodes using the same audio codec</dd>
+      <dt>-vn</dt><dd>no video stream</dd>
+      <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
+    </dl>
+  </div>
+  <!-- ends Extract audio from am AV file -->
+
+  <!-- Combine audio tracks  -->
+  <span data-toggle="collapse" data-target="#combine_audio"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Combine audio tracks">Combine audio tracks</button></span>
+  <div id="combine_audio" class="collapse">
+    <h3>Combine audio tracks into one in a video file</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -filter_complex "[0:a:0][0:a:1]amerge[out]" -map 0:v -map "[out]" -c:v copy -shortest <i>output_file</i></code></p>
+    <p>This command combines two audio tracks present in a video file into one stream. It can be useful in situations where a downstream process, like YouTube’s automatic captioning, expect one audio track. To ensure that you’re mapping the right audio tracks run ffprobe before writing the script to identify which tracks are desired. More than two audio streams can be combined by extending the pattern present in the -filter_complex option.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-filter_complex </dt><dd>tells fmpeg that we will be using a complex filter</dd>
+      <dt>"</dt><dd>quotation mark to start filtergraph</dd>
+      <dt>[0:a:0][0:a:1]amerge[out]</dt><dd>combines the two audio tracks into one</dd>
+      <dt>"</dt><dd>quotation mark to end filtergraph</dd>
+      <dt>-map 0:v</dt><dd>map the video</dd>
+      <dt>-map "[out]"</dt><dd>map the combined audio defined by the filter</dd>
+      <dt>-c:v copy</dt><dd>copy the video</dd>
+      <dt>-shortest</dt><dd>limit to the shortest stream</dd>
+      <dt><i>output_file</i></dt><dd>path, name and extension of the video output file</dd>
+    </dl>
+  </div>
+  <!-- ends Combine audio tracks  -->
+
+  <!-- phase shift -->
+  <span data-toggle="collapse" data-target="#phase_shift"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Inverses the audio phase of the second channel">Flip phase shift</button></span>
+  <div id="phase_shift" class="collapse">
+    <h3>Flip audio phase shift</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -af pan="stereo|c0=c0|c1=-1*c1" <i>output_file</i></code></p>
+    <p>This command inverses the audio phase of the second channel by rotating it 180°.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt>-i <i>input file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-af</dt><dd>specifies that the next section should be interpreted as an audio filter</dd>
+      <dt>pan=</dt><dd>tell the quoted text below to use the <a href="https://ffmpeg.org/ffmpeg-filters.html#pan-1" target="_blank">pan filter</a></dd>
+      <dt>"stereo|c0=c0|c1=-1*c1"</dt><dd>maps the output's first channel (c0) to the input's first channel and the output's second channel (c1) to the inverse of the input's second channel</dd>
+      <dt><i>output file</i></dt><dd>path, name and extension of the output file</dd>
+    </dl>
+  </div>
+  <!-- ends phase shift -->
+
+  <!-- loudnorm metadata -->
+  <span data-toggle="collapse" data-target="#loudnorm_metadata"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Calculate Loudness Levels">Calculate Loudness Levels</button></span>
+  <div id="loudnorm_metadata" class="collapse">
+    <h3>Calculate Loudness Levels</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -af loudnorm=print_format=json -f null -</code></p>
+    <p>This filter calculates and outputs loudness information in json about an input file (labeled input) as well as what the levels would be if loudnorm were applied in its one pass mode (labeled output). The values generated can be used as inputs for a 'second pass' of the loudnorm filter allowing more accurate loudness normalization than if it is used in a single pass.</p>
+    <p>These instructions use the loudnorm defaults, which align well with PBS recommendations for target loudness. More information can be found at the <a href="https://ffmpeg.org/ffmpeg-filters.html#loudnorm" target="_blank">loudnorm documentation</a>.</p>
+    <p>Information about PBS loudness standards can be found in the <a href="http://www-tc.pbs.org/capt/Producing/TOS-2012-Pt2-Distribution.pdf" target="_blank">PBS Technical Operating Specifications</a> document. Information about EBU loudness standards can be found in the <a href="https://tech.ebu.ch/docs/r/r128-2014.pdf" target="_blank">EBU R 128</a> recommendation document.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-af loudnorm</dt><dd>activates the loudnorm filter</dd>
+      <dt>print_format=json</dt><dd>sets the output format for loudness information to json. This format makes it easy to use in a second pass. For a more human readable output, this can be set to <code>print_format=summary</code></dd>
+      <dt><i>-f null -</i></dt><dd>sets the file output to null (since we are only interested in the metadata generated)</dd>
+    </dl>
+  </div>
+  <!-- ends loudnorm metadata -->
+
+  <!-- RIAA equalization -->
+  <span data-toggle="collapse" data-target="#riaa_eq"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="RIAA Equalization">RIAA Equalization</button></span>
+  <div id="riaa_eq" class="collapse">
+    <h3>RIAA Equalization</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -af aemphasis=type=riaa <i>output_file</i></code></p>
+    <p>This will apply RIAA equalization to an input file allowing correct listening of audio transferred 'flat' (without EQ) from records that used this EQ curve. For more information about RIAA equalization see the <a href="https://en.wikipedia.org/wiki/RIAA_equalization" target="_blank">Wikipedia page</a> on the subject.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-af aemphasis=type=riaa</dt><dd>activates the aemphasis filter and sets it to use RIAA equalization</dd>
+      <dt><i>output_file</i></dt><dd>path and name of output file</dd>
+    </dl>
+  </div>
+  <!-- ends RIAA equalization -->
+
+  <!-- one pass loudnorm -->
+  <span data-toggle="collapse" data-target="#loudnorm_one_pass"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="One Pass Loudness Normalization">One Pass Loudness Normalization</button></span>
+  <div id="loudnorm_one_pass" class="collapse">
+    <h3>One Pass Loudness Normalization</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -af loudnorm=dual_mono=true -ar 48k <i>output_file</i></code></p>
+    <p>This will normalize the loudness of an input using one pass, which is quicker but less accurate than using two passes. This command uses the loudnorm filter defaults for target loudness. These defaults align well with PBS recommendations, but loudnorm does allow targeting of specific loudness levels. More information can be found at the <a href="https://ffmpeg.org/ffmpeg-filters.html#loudnorm" target="_blank">loudnorm documentation</a>.</p>
+    <p>Information about PBS loudness standards can be found in the <a href="http://www-tc.pbs.org/capt/Producing/TOS-2012-Pt2-Distribution.pdf" target="_blank">PBS Technical Operating Specifications</a> document. Information about EBU loudness standards can be found in the <a href="https://tech.ebu.ch/docs/r/r128-2014.pdf" target="_blank">EBU R 128</a> recommendation document.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-af loudnorm</dt><dd>activates the loudnorm filter with default settings</dd>
+      <dt>dual_mono=true</dt><dd>(optional) Use this for mono files meant to be played back on stereo systems for correct loudness. Not necessary for multi-track inputs.</dd>
+      <dt>-ar 48k</dt><dd>Sets the output sample rate to 48 kHz. (The loudnorm filter upsamples to 192 kHz so it is best to manually set a desired output sample rate).</dd>
+      <dt><i>output_file</i></dt><dd>path, name and extension for output file</dd>
+    </dl>
+  </div>
+  <!-- ends one pass loudnorm -->
+
+  <!-- two pass loudnorm -->
+  <span data-toggle="collapse" data-target="#loudnorm_two_pass"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Two Pass Loudness Normalization">Two Pass Loudness Normalization</button></span>
+  <div id="loudnorm_two_pass" class="collapse">
+    <h3>Two Pass Loudness Normalization</h3>
+    <p class="link"></p>
+    <p><code>ffmpeg -i <i>input_file</i> -af loudnorm=dual_mono=true:measured_I=<i>input_i</i>:measured_TP=<i>input_tp</i>:measured_LRA=<i>input_lra</i>:measured_thresh=<i>input_thresh</i>:offset=<i>target_offset</i>:linear=true -ar 48k <i>output_file</i></code></p>
+    <p>This command allows using the levels calculated using a <a href="#loudnorm_metadata">first pass of the loudnorm filter</a> to more accurately normalize loudness. This command uses the loudnorm filter defaults for target loudness. These defaults align well with PBS recommendations, but loudnorm does allow targeting of specific loudness levels. More information can be found at the <a href="https://ffmpeg.org/ffmpeg-filters.html#loudnorm" target="_blank">loudnorm documentation</a>.</p>
+    <p>Information about PBS loudness standards can be found in the <a href="http://www-tc.pbs.org/capt/Producing/TOS-2012-Pt2-Distribution.pdf" target="_blank">PBS Technical Operating Specifications</a> document. Information about EBU loudness standards can be found in the <a href="https://tech.ebu.ch/docs/r/r128-2014.pdf" target="_blank">EBU R 128</a> recommendation document.</p>
+    <dl>
+      <dt>ffmpeg</dt><dd>starts the command</dd>
+      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
+      <dt>-af loudnorm</dt><dd>activates the loudnorm filter with default settings</dd>
+      <dt>dual_mono=true</dt><dd>(optional) use this for mono files meant to be played back on stereo systems for correct loudness. Not necessary for multi-track inputs.</dd>
+      <dt>measured_I=<i>input_i</i></dt><dd>use the 'input_i' value (integrated loudness) from the first pass in place of input_i</dd>
+      <dt>measured_TP=<i>input_tp</i></dt><dd>use the 'input_tp' value (true peak) from the first pass in place of input_tp</dd>
+      <dt>measured_LRA=<i>input_lra</i></dt><dd>use the 'input_lra' value (loudness range) from the first pass in place of input_lra</dd>
+      <dt>measured_LRA=<i>input_thresh</i></dt><dd>use the 'input_thresh' value (threshold) from the first pass in place of input_thresh</dd>
+      <dt>offset=<i>target_offset</i></dt><dd>use the 'target_offset' value (offset) from the first pass in place of target_offset</dd>
+      <dt>linear=true</dt><dd>tells loudnorm to use linear normalization</dd>
+      <dt>-ar 48k</dt><dd>Sets the output sample rate to 48 kHz. (The loudnorm filter upsamples to 192 kHz so it is best to manually set a desired output sample rate).</dd>
+      <dt><i>output_file</i></dt><dd>path, name and extension for output file</dd>
+    </dl>
+  </div>
+  <!-- ends two pass loudnorm -->
 
   </div>
   <div class="well">
@@ -922,7 +1087,7 @@ e.g.: <code>ffmpeg -f concat -safe 0 -i mylist.txt -c copy <i>output_file</i></c
 
   </div>
   <div class="well">
-  <h2 id="create-thumbnails">Generate image files from a video</h2>
+  <h2 id="create-images">Create thumbnails or GIFs</h2>
 
   <!-- One thumbnail -->
   <span data-toggle="collapse" data-target="#one_thumbnail"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Export one thumbnail per video file">One thumbnail</button></span>
@@ -957,10 +1122,6 @@ e.g.: <code>ffmpeg -f concat -safe 0 -i mylist.txt -c copy <i>output_file</i></c
     </dl>
   </div>
   <!-- ends Multi thumbnail -->
-
-  </div>
-  <div class="well">
-  <h2 id="animated-gif">Create an animated GIF</h2>
 
   <!-- Images to GIF -->
   <span data-toggle="collapse" data-target="#img_to_gif"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Converts images to GIF">Create GIF from still images</button></span>
@@ -1184,107 +1345,6 @@ e.g.: <code>ffmpeg -f concat -safe 0 -i mylist.txt -c copy <i>output_file</i></c
     </div>
   </div>
   <!-- ends Side by Side Videos/Temporal Difference Filter -->
-
-  </div>
-  <div class="well">
-  <h2 id="normalise-audio">Normalize/equalize audio</h2>
-
-  <!-- phase shift -->
-  <span data-toggle="collapse" data-target="#phase_shift"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Inverses the audio phase of the second channel">Flip phase shift</button></span>
-  <div id="phase_shift" class="collapse">
-    <h3>Flip audio phase shift</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -af pan="stereo|c0=c0|c1=-1*c1" <i>output_file</i></code></p>
-    <p>This command inverses the audio phase of the second channel by rotating it 180°.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt>-i <i>input file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-af</dt><dd>specifies that the next section should be interpreted as an audio filter</dd>
-      <dt>pan=</dt><dd>tell the quoted text below to use the <a href="https://ffmpeg.org/ffmpeg-filters.html#pan-1" target="_blank">pan filter</a></dd>
-      <dt>"stereo|c0=c0|c1=-1*c1"</dt><dd>maps the output's first channel (c0) to the input's first channel and the output's second channel (c1) to the inverse of the input's second channel</dd>
-      <dt><i>output file</i></dt><dd>path, name and extension of the output file</dd>
-    </dl>
-  </div>
-  <!-- ends phase shift -->
-
-  <!-- loudnorm metadata -->
-  <span data-toggle="collapse" data-target="#loudnorm_metadata"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Calculate Loudness Levels">Calculate Loudness Levels</button></span>
-  <div id="loudnorm_metadata" class="collapse">
-    <h3>Calculate Loudness Levels</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -af loudnorm=print_format=json -f null -</code></p>
-    <p>This filter calculates and outputs loudness information in json about an input file (labeled input) as well as what the levels would be if loudnorm were applied in its one pass mode (labeled output). The values generated can be used as inputs for a 'second pass' of the loudnorm filter allowing more accurate loudness normalization than if it is used in a single pass.</p>
-    <p>These instructions use the loudnorm defaults, which align well with PBS recommendations for target loudness. More information can be found at the <a href="https://ffmpeg.org/ffmpeg-filters.html#loudnorm" target="_blank">loudnorm documentation</a>.</p>
-    <p>Information about PBS loudness standards can be found in the <a href="http://www-tc.pbs.org/capt/Producing/TOS-2012-Pt2-Distribution.pdf" target="_blank">PBS Technical Operating Specifications</a> document. Information about EBU loudness standards can be found in the <a href="https://tech.ebu.ch/docs/r/r128-2014.pdf" target="_blank">EBU R 128</a> recommendation document.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-af loudnorm</dt><dd>activates the loudnorm filter</dd>
-      <dt>print_format=json</dt><dd>sets the output format for loudness information to json. This format makes it easy to use in a second pass. For a more human readable output, this can be set to <code>print_format=summary</code></dd>
-      <dt><i>-f null -</i></dt><dd>sets the file output to null (since we are only interested in the metadata generated)</dd>
-    </dl>
-  </div>
-  <!-- ends loudnorm metadata -->
-
-  <!-- RIAA equalization -->
-  <span data-toggle="collapse" data-target="#riaa_eq"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="RIAA Equalization">RIAA Equalization</button></span>
-  <div id="riaa_eq" class="collapse">
-    <h3>RIAA Equalization</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -af aemphasis=type=riaa <i>output_file</i></code></p>
-    <p>This will apply RIAA equalization to an input file allowing correct listening of audio transferred 'flat' (without EQ) from records that used this EQ curve. For more information about RIAA equalization see the <a href="https://en.wikipedia.org/wiki/RIAA_equalization" target="_blank">Wikipedia page</a> on the subject.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-af aemphasis=type=riaa</dt><dd>activates the aemphasis filter and sets it to use RIAA equalization</dd>
-      <dt><i>output_file</i></dt><dd>path and name of output file</dd>
-    </dl>
-  </div>
-  <!-- ends RIAA equalization -->
-
-  <!-- one pass loudnorm -->
-  <span data-toggle="collapse" data-target="#loudnorm_one_pass"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="One Pass Loudness Normalization">One Pass Loudness Normalization</button></span>
-  <div id="loudnorm_one_pass" class="collapse">
-    <h3>One Pass Loudness Normalization</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -af loudnorm=dual_mono=true -ar 48k <i>output_file</i></code></p>
-    <p>This will normalize the loudness of an input using one pass, which is quicker but less accurate than using two passes. This command uses the loudnorm filter defaults for target loudness. These defaults align well with PBS recommendations, but loudnorm does allow targeting of specific loudness levels. More information can be found at the <a href="https://ffmpeg.org/ffmpeg-filters.html#loudnorm" target="_blank">loudnorm documentation</a>.</p>
-    <p>Information about PBS loudness standards can be found in the <a href="http://www-tc.pbs.org/capt/Producing/TOS-2012-Pt2-Distribution.pdf" target="_blank">PBS Technical Operating Specifications</a> document. Information about EBU loudness standards can be found in the <a href="https://tech.ebu.ch/docs/r/r128-2014.pdf" target="_blank">EBU R 128</a> recommendation document.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-af loudnorm</dt><dd>activates the loudnorm filter with default settings</dd>
-      <dt>dual_mono=true</dt><dd>(optional) Use this for mono files meant to be played back on stereo systems for correct loudness. Not necessary for multi-track inputs.</dd>
-      <dt>-ar 48k</dt><dd>Sets the output sample rate to 48 kHz. (The loudnorm filter upsamples to 192 kHz so it is best to manually set a desired output sample rate).</dd>
-      <dt><i>output_file</i></dt><dd>path, name and extension for output file</dd>
-    </dl>
-  </div>
-  <!-- ends one pass loudnorm -->
-
-  <!-- two pass loudnorm -->
-  <span data-toggle="collapse" data-target="#loudnorm_two_pass"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Two Pass Loudness Normalization">Two Pass Loudness Normalization</button></span>
-  <div id="loudnorm_two_pass" class="collapse">
-    <h3>Two Pass Loudness Normalization</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -af loudnorm=dual_mono=true:measured_I=<i>input_i</i>:measured_TP=<i>input_tp</i>:measured_LRA=<i>input_lra</i>:measured_thresh=<i>input_thresh</i>:offset=<i>target_offset</i>:linear=true -ar 48k <i>output_file</i></code></p>
-    <p>This command allows using the levels calculated using a <a href="#loudnorm_metadata">first pass of the loudnorm filter</a> to more accurately normalize loudness. This command uses the loudnorm filter defaults for target loudness. These defaults align well with PBS recommendations, but loudnorm does allow targeting of specific loudness levels. More information can be found at the <a href="https://ffmpeg.org/ffmpeg-filters.html#loudnorm" target="_blank">loudnorm documentation</a>.</p>
-    <p>Information about PBS loudness standards can be found in the <a href="http://www-tc.pbs.org/capt/Producing/TOS-2012-Pt2-Distribution.pdf" target="_blank">PBS Technical Operating Specifications</a> document. Information about EBU loudness standards can be found in the <a href="https://tech.ebu.ch/docs/r/r128-2014.pdf" target="_blank">EBU R 128</a> recommendation document.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt><i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-af loudnorm</dt><dd>activates the loudnorm filter with default settings</dd>
-      <dt>dual_mono=true</dt><dd>(optional) use this for mono files meant to be played back on stereo systems for correct loudness. Not necessary for multi-track inputs.</dd>
-      <dt>measured_I=<i>input_i</i></dt><dd>use the 'input_i' value (integrated loudness) from the first pass in place of input_i</dd>
-      <dt>measured_TP=<i>input_tp</i></dt><dd>use the 'input_tp' value (true peak) from the first pass in place of input_tp</dd>
-      <dt>measured_LRA=<i>input_lra</i></dt><dd>use the 'input_lra' value (loudness range) from the first pass in place of input_lra</dd>
-      <dt>measured_LRA=<i>input_thresh</i></dt><dd>use the 'input_thresh' value (threshold) from the first pass in place of input_thresh</dd>
-      <dt>offset=<i>target_offset</i></dt><dd>use the 'target_offset' value (offset) from the first pass in place of target_offset</dd>
-      <dt>linear=true</dt><dd>tells loudnorm to use linear normalization</dd>
-      <dt>-ar 48k</dt><dd>Sets the output sample rate to 48 kHz. (The loudnorm filter upsamples to 192 kHz so it is best to manually set a desired output sample rate).</dd>
-      <dt><i>output_file</i></dt><dd>path, name and extension for output file</dd>
-    </dl>
-  </div>
-  <!-- ends two pass loudnorm -->
 
   </div>
   <div class="well">
@@ -1810,71 +1870,6 @@ ffmpeg -i $file -map 0 -c copy $output
     </dl>
   </div>
   <!-- ends Split audio and video tracks -->
-
-  <!-- Extract audio from an AV file -->
-  <span data-toggle="collapse" data-target="#extract_audio"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Extract audio without loss from an AV file">Extract audio</button></span>
-  <div id="extract_audio" class="collapse">
-    <h3>Extract audio from an AV file</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -c:a copy -vn <i>output_file</i></code></p>
-    <p>This command extracts the audio stream without loss from an audiovisual file.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-c:a copy</dt><dd>re-encodes using the same audio codec</dd>
-      <dt>-vn</dt><dd>no video stream</dd>
-      <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
-    </dl>
-  </div>
-  <!-- ends Extract audio from am AV file -->
-
-  <!-- Combine audio tracks  -->
-  <span data-toggle="collapse" data-target="#combine_audio"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Combine audio tracks">Combine audio tracks</button></span>
-  <div id="combine_audio" class="collapse">
-    <h3>Combine audio tracks into one in a video file</h3>
-    <p class="link"></p>
-    <p><code>ffmpeg -i <i>input_file</i> -filter_complex "[0:a:0][0:a:1]amerge[out]" -map 0:v -map "[out]" -c:v copy -shortest <i>output_file</i></code></p>
-    <p>This command combines two audio tracks present in a video file into one stream. It can be useful in situations where a downstream process, like YouTube’s automatic captioning, expect one audio track. To ensure that you’re mapping the right audio tracks run ffprobe before writing the script to identify which tracks are desired. More than two audio streams can be combined by extending the pattern present in the -filter_complex option.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
-      <dt>-filter_complex </dt><dd>tells fmpeg that we will be using a complex filter</dd>
-      <dt>"</dt><dd>quotation mark to start filtergraph</dd>
-      <dt>[0:a:0][0:a:1]amerge[out]</dt><dd>combines the two audio tracks into one</dd>
-      <dt>"</dt><dd>quotation mark to end filtergraph</dd>
-      <dt>-map 0:v</dt><dd>map the video</dd>
-      <dt>-map "[out]"</dt><dd>map the combined audio defined by the filter</dd>
-      <dt>-c:v copy</dt><dd>copy the video</dd>
-      <dt>-shortest</dt><dd>limit to the shortest stream</dd>
-      <dt><i>output_file</i></dt><dd>path, name and extension of the video output file</dd>
-    </dl>
-  </div>
-  <!-- ends Combine audio tracks  -->
-
-  <!-- append notice to access mp3 -->
-  <span data-toggle="collapse" data-target="#append_mp3"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Generate two access MP3s from input. One with added audio (such as a copyright notice) and one unmodified.">Create access MP3</button></span>
-  <div id="append_mp3" class="collapse">
-    <h3>Generate two access MP3s from input. One with appended audio (such as a copyright notice) and one unmodified.</h3>
-    <p class="link"></p>
-    <p> <code>ffmpeg -i <i>input_file</i> -i <i>input_file_to_append</i> -filter_complex "[0:a:0]asplit=2[a][b];[b]afifo[bb];[1:a:0][bb]concat=n=2:v=0:a=1[concatout]" -map "[a]" -codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2 <i>output_file.mp3</i> -map "[concatout]" -codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2 <i>output_file_appended.mp3</i></code></p>
-    <p>This script allows you to generate two derivative audio files from a master while appending audio from a separate file (for example a copyright or institutional notice) to one of them.</p>
-    <dl>
-      <dt>ffmpeg</dt><dd>starts the command</dd>
-      <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file (the master file)</dd>
-      <dt>-i <i>input_file_to_append</i></dt><dd>path, name and extension of the input file (the file to be appended to access file)</dd>
-      <dt>-filter_complex</dt><dd>enables the complex filtering to manage splitting the input to two audio streams</dd>
-      <dt>[0:a:0]asplit=2[a][b];</dt><dd><code>asplit</code> allows audio streams to be split up for separate manipulation. This command splits the audio from the first input (the master file) into two streams "a" and "b"</dd>
-      <dt>[b]afifo[bb];</dt><dd>this buffers the stream "b" to help prevent dropped samples and renames stream to "bb"</dd>
-      <dt>[1:a:0][bb]concat=n=2:v=0:a=1[concatout]</dt><dd><code>concat</code> is used to join files. <code>n=2</code> tells the filter there are two inputs. <code>v=0:a=1</code> Tells the filter there are 0 video outputs and 1 audio output. This command appends the audio from the second input to the beginning of stream "bb" and names the output "concatout"</dd>
-      <dt>-map "[a]"</dt><dd>this maps the unmodified audio stream to the first output</dd>
-      <dt>-codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2</dt><dd>sets up MP3 options (using constant quality)</dd>
-      <dt><i>output_file</i></dt><dd>path, name and extension of the output file (unmodified)</dd>
-      <dt>-map "[concatout]"</dt><dd>this maps the modified stream to the second output</dd>
-      <dt>-codec:a libmp3lame -dither_method modified_e_weighted -qscale:a 2</dt><dd>sets up MP3 options (using constant quality)</dd>
-      <dt><i>output_file_appended</i></dt><dd>path, name and extension of the output file (with appended notice)</dd>
-    </dl>
-  </div>
-  <!-- ends append notice to access mp3 -->
 
   <!-- Flip image -->
   <span data-toggle="collapse" data-target="#flip_image"><button type="button" class="btn" data-toggle="tooltip" data-placement="bottom" title="Flip the image">Flip video image</button></span>


### PR DESCRIPTION
Following discussion in #237 ....

- Recipes about creating thumbnails or GIFs now grouped together in the section "Create thumbnails or GIFs"
- New section: "Change or view audio properties". This replaces the previous section "Normalize/equalize audio", combining the recipes that were in that section with other audio recipes (**edit** - now including the repair one, thus deleting the "Repair" section).
   - **Question**: Is _Change or view audio properties_ a good section name?
- Access mp3 with copyright notice recipe moved to "Change codec" section, where it seems to belong better. (I didn't edit this, just moved it - over to you @privatezero :) )