### PR TITLE
Remove max width for content <div>

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -24,7 +24,6 @@ html, body {
 
 .content {
   grid-area: content;
-  max-width: 900px;
 }
 
 .sidebar {


### PR DESCRIPTION
Just a small CSS fix. On large screens, the content `div` doesn't grow to full size of the grid, leaving the page off-kilter.

before:
![ffmprovisr_full3](https://user-images.githubusercontent.com/16832997/31867783-642d3d58-b7f1-11e7-8168-c15ebe29324c.PNG)

showing grid:
![ffmprovisr_full3_grid](https://user-images.githubusercontent.com/16832997/31867785-6493297e-b7f1-11e7-899e-e31a697101cc.PNG)

after:
![ffmprovisr_full3_after](https://user-images.githubusercontent.com/16832997/31867784-64604860-b7f1-11e7-91df-717a70f2a700.PNG)

