### PR TITLE
Fix sizing issue at large resolutions

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -61,6 +61,10 @@ html, body {
   .grid {
     max-width: 70%;
     margin: 0 auto;
+    grid-template-areas:
+    "header  header"
+    "sidebar content"
+    "footer  footer";
   }
 }
 


### PR DESCRIPTION
So, I noticed that the `min-width: 1500px` media query wasn't working correctly. It seemed to be kicking in at 1200px instead of 1500px. This commit fixes this. To explain visually:

BEFORE --

Here I'm at just under 1200px. Full screen coverage, as you'd expect.
![ffmprovisr_mq_1](https://user-images.githubusercontent.com/16832997/32167795-f8723dd2-bdce-11e7-8338-bdabf318893d.png)

Then I widen to just over 1200px ... and the 1500px `min-width` media query kicks in! Qué?
![ffmprovisr_mq_2](https://user-images.githubusercontent.com/16832997/32168239-a4fb7bbc-bdd0-11e7-8da8-ecca8e74595c.png)

AFTER -- 

At widths up til 1500px, the media query doesn't kick in.
![ffmprovisr_mq_3](https://user-images.githubusercontent.com/16832997/32168274-c893a310-bdd0-11e7-85f3-cee2c1a4f66e.png)

Then it does!
![ffmprovisr_mq_4](https://user-images.githubusercontent.com/16832997/32168280-ceaa7a4e-bdd0-11e7-922e-c2fb9f80f180.png)

I'm not totally sure exactly why the bug was occurring - I'm not well versed in CSS grid yet. So I'll appreciate your eagle eyes, @ablwr 👀 😄 