### PR TITLE
Add max width on example images

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -138,7 +138,10 @@ img {
 }
 
 .sample-image {
+  margin: 0 auto;
   margin-bottom: 18px;
+  max-width: 500px;
+  text-align: center;
 }
 
 div {


### PR DESCRIPTION
In the distant past, there was a `max-width` property set on the `img` element, but this has been lost in the shuffle. I've added something similar back, so that the images aren't super giant.

Before -
![ffmprovisr_before](https://user-images.githubusercontent.com/16832997/32220074-33639384-be95-11e7-896a-effb3c2ddbdf.PNG)

After -
![ffmprov_after](https://user-images.githubusercontent.com/16832997/32220172-a567a9f2-be95-11e7-86a0-7277d67f7aa5.PNG)

It may still need tweaking.