### PR TITLE
lifts the break-all and sets a max-width on code for long lines

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -118,7 +118,7 @@ code {
   color: #c7254e;
   background-color: #f9f2f4;
   border-radius: 4px;
-  word-break: break-all;
+  max-width: 800px;
   word-wrap: break-word;
   white-space: normal;
   display: inline-block;

--- a/css/css.css
+++ b/css/css.css
@@ -44,6 +44,9 @@ html, body {
     "content"
     "footer";
   }
+  code {
+    word-break: break-all;
+  }
 }
 
 @media only screen and (min-width: 1000px) {
@@ -118,8 +121,8 @@ code {
   color: #c7254e;
   background-color: #f9f2f4;
   border-radius: 4px;
-  max-width: 800px;
   word-wrap: break-word;
+  max-width: 800px;
   white-space: normal;
   display: inline-block;
 }


### PR DESCRIPTION
This is for #276, please test on many browsers and systems. Sets a maximum size for the code block and breaks at the line when necessary. When screens are very small, it will break at any point it deems appropriate.

Works on Mac with Firefox (my default), Chrome and Safari.

Works in Firefox and Chrome mobile views.