### PR TITLE
New recipe: concat files of different types (+ a few fixups)

### DIFF
--- a/index.html
+++ b/index.html
@@ -913,8 +913,7 @@
     <label class="recipe" for="join_different_files">Join (concatenate) two or more files of different types</label>
      <input type="checkbox" id="join_different_files">
      <div class="hiding">
-       <h3>Join files together</h3>
-      <!-- ffmpeg -i input1.mov -i input2.avi -filter_complex "[0:v:0][0:a:0][1:v:0][1:a:0]concat=n=2:v=1:a=1[outv][outa]" -map "[outv]" -map "[outa]" output.mkv -->
+      <h3>Join files together</h3>
       <p><code>ffmpeg -i input1.avi -i input2.mp4 -filter_complex "[0:v:0][0:a:0][1:v:0][1:a:0]concat=n=2:v=1:a=1[videoOut][audioOut]" -map "[videoOut]" -map "[audioOut]" <i>output_file</i></code></p>
       <p>
         This command takes two or more files of the different file types and joins them together to make a single file.<br>
@@ -924,10 +923,10 @@
         <dt>ffmpeg</dt><dd>starts the command</dd>
         <dt>-i <i>input1.ext</i></dt><dd>path, name and extension of the first input file</dd>
         <dt>-i <i>input2.ext</i></dt><dd>path, name and extension of the second input file</dd>
-        <dt>-filter_complex</dt><dd>starts the complex filtergraph</dd>
+        <dt>-filter_complex</dt><dd>states that a complex filtergraph will be used</dd>
         <dt>"</dt><dd>quotation mark to start filtergraph</dd>
         <dt>[0:v:0][0:a:0]</dt><dd>selects the first video stream and first audio stream from the first input.<br>
-          References to different streams are each enclosed in square brackets. In the first stream reference, <code>0:v:0</code>, the first zero refers to the first input file, <code>v</code> means video stream, and the second zero indicates that it is the <i>first</i> video stream in the file that should be selected. Likewise, <code>0:a:0</code> means the first audio stream in the first input file.<br>
+          Each reference to a specific stream is enclosed in square brackets. In the first stream reference, <code>0:v:0</code>, the first zero refers to the first input file, <code>v</code> means video stream, and the second zero indicates that it is the <i>first</i> video stream in the file that should be selected. Likewise, <code>0:a:0</code> means the first audio stream in the first input file.<br>
           As demonstrated above, ffmpeg uses zero-indexing: <code>0</code> means the first input/stream/etc, <code>1</code> means the second input/stream/etc, and <code>4</code> would mean the fifth input/stream/etc.</dd>
         <dt>[1:v:0][1:a:0]</dt><dd>As described above, this means select the first video and audio streams from the second input file.</dd>
         <dt>concat=</dt><dd>starts the <code>concat</code> filter</dd>

--- a/index.html
+++ b/index.html
@@ -250,18 +250,19 @@
     <input type="checkbox" id="transcode_h264">
     <div class="hiding">
       <h3>Transcode to H.264</h3>
-      <p><code>ffmpeg -i <i>input_file</i> -c:v libx264 -pix_fmt yuv420p -c:a copy <i>output_file</i></code></p>
+      <p><code>ffmpeg -i <i>input_file</i> -c:v libx264 -pix_fmt yuv420p -c:a aac <i>output_file</i></code></p>
       <p>This command takes an input file and transcodes it to H.264 with an .mp4 wrapper, keeping the audio the same codec as the original. The libx264 codec defaults to a “medium” preset for compression quality and a CRF of 23. CRF stands for constant rate factor and determines the quality and file size of the resulting H.264 video. A low CRF means high quality and large file size; a high CRF means the opposite.</p>
       <dl>
         <dt>ffmpeg</dt><dd>starts the command</dd>
         <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
         <dt>-c:v libx264</dt><dd>tells FFmpeg to encode the video stream as H.264</dd>
         <dt>-pix_fmt yuv420p</dt><dd>libx264 will use a chroma subsampling scheme that is the closest match to that of the input. This can result in Y′C<sub>B</sub>C<sub>R</sub> 4:2:0, 4:2:2, or 4:4:4 chroma subsampling. QuickTime and most other non-FFmpeg based players can’t decode H.264 files that are not 4:2:0. In order to allow the video to play in all players, you can specify 4:2:0 chroma subsampling.</dd>
-        <dt>-c:a copy</dt><dd>tells FFmpeg to copy the audio stream without re-encoding it</dd>
+        <dt>-c:a aac</dt><dd>encode audio as AAC.<br>
+          AAC is the codec most often used for audio streams within an .mp4 container.</dd>
         <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
       </dl>
       <p>In order to use the same basic command to make a higher quality file, you can add some of these presets:</p>
-      <p><code>ffmpeg -i <i>input_file</i> -c:v libx264 -pix_fmt yuv420p -preset veryslow -crf 18 -c:a copy <i>output_file</i></code></p>
+      <p><code>ffmpeg -i <i>input_file</i> -c:v libx264 -pix_fmt yuv420p -preset veryslow -crf 18 -c:a aac <i>output_file</i></code></p>
       <dl>
         <dt>-preset <i>veryslow</i></dt><dd>This option tells FFmpeg to use the slowest preset possible for the best compression quality.<br>
         Available presets, from slowest to fastest, are: <code>veryslow</code>, <code>slower</code>, <code>slow</code>, <code>medium</code>, <code>fast</code>, <code>faster</code>, <code>veryfast</code>, <code>superfast</code>, <code>ultrafast</code>.</dd>
@@ -332,7 +333,7 @@
     <input type="checkbox" id="dvd_to_file">
     <div class="hiding">
       <h3>Convert DVD to H.264</h3>
-      <p><code>ffmpeg -i concat:<i>input_file1</i>\|<i>input_file2</i>\|<i>input_file3</i> -c:v libx264 -c:a copy <i>output_file</i>.mp4</code></p>
+      <p><code>ffmpeg -i concat:<i>input_file1</i>\|<i>input_file2</i>\|<i>input_file3</i> -c:v libx264 -c:a aac <i>output_file</i>.mp4</code></p>
       <p>This command allows you to create an H.264 file from a DVD source that is not copy-protected.</p>
       <p>Before encoding, you’ll need to establish which of the .VOB files on the DVD or .iso contain the content that you wish to encode. Inside the VIDEO_TS directory, you will see a series of files with names like VTS_01_0.VOB, VTS_01_1.VOB, etc. Some of the .VOB files will contain menus, special features, etc, so locate the ones that contain target content by playing them back in VLC.</p>
       <dl>
@@ -341,17 +342,18 @@
         <code>-i concat:VTS_01_1.VOB\|VTS_01_2.VOB\|VTS_01_3.VOB</code><br>
         The backslash is simply an escape character for the pipe (<b>|</b>).</dd>
         <dt>-c:v libx264</dt><dd>sets the video codec as H.264</dd>
-        <dt>-c:a copy</dt><dd>audio remains as-is (no re-encode)</dd>
+        <dt>-c:a aac</dt><dd>encode audio as AAC.<br>
+          AAC is the codec most often used for audio streams within an .mp4 container.</dd>
         <dt><i>output_file.mp4</i></dt><dd>path and name of the output file</dd>
       </dl>
       <p>It’s also possible to adjust the quality of your output by setting the <b>-crf</b> and <b>-preset</b> values:</p>
-      <p><code>ffmpeg -i concat:<i>input_file1</i>\|<i>input_file2</i>\|<i>input_file3</i> -c:v libx264 -crf 18 -preset veryslow -c:a copy <i>output_file</i>.mp4</code></p>
+      <p><code>ffmpeg -i concat:<i>input_file1</i>\|<i>input_file2</i>\|<i>input_file3</i> -c:v libx264 -crf 18 -preset veryslow -c:a aac <i>output_file</i>.mp4</code></p>
       <dl>
         <dt>-crf 18</dt><dd>sets the constant rate factor to a visually lossless value. Libx264 defaults to a <a href="https://trac.ffmpeg.org/wiki/Encode/H.264#crf" target="_blank">crf of 23</a>, considered medium quality; a smaller CRF value produces a larger and higher quality video.</dd>
         <dt>-preset veryslow</dt><dd>A slower preset will result in better compression and therefore a higher-quality file. The default is <b>medium</b>; slower presets are <b>slow</b>, <b>slower</b>, and <b>veryslow</b>.</dd>
       </dl>
       <p>Bear in mind that by default, libx264 will only encode a single video stream and a single audio stream, picking the ‘best’ of the options available. To preserve all video and audio streams, add <b>-map</b> parameters:</p>
-      <p><code>ffmpeg -i concat:<i>input_file1</i>\|<i>input_file2</i> -map 0:v -map 0:a -c:v libx264 -c:a copy <i>output_file</i>.mp4</code></p>
+      <p><code>ffmpeg -i concat:<i>input_file1</i>\|<i>input_file2</i> -map 0:v -map 0:a -c:v libx264 -c:a aac <i>output_file</i>.mp4</code></p>
       <dl>
         <dt>-map 0:v</dt><dd>encodes all video streams</dd>
         <dt>-map 0:a</dt><dd>encodes all audio streams</dd>

--- a/index.html
+++ b/index.html
@@ -882,8 +882,8 @@
     <div class="well">
     <h2 id="join-trim">Join, trim, or excerpt a video</h2>
 
-    <!-- Join files together -->
-    <label class="recipe" for="join_files">Join (concatenate) two or more files into a single file</label>
+    <!-- Join files of the same type together -->
+    <label class="recipe" for="join_files">Join (concatenate) two or more files of the same type</label>
     <input type="checkbox" id="join_files">
     <div class="hiding">
       <h3>Join files together</h3>
@@ -907,7 +907,49 @@
       <p>For more information, see the <a href="https://trac.ffmpeg.org/wiki/Concatenate" target="_blank">FFmpeg wiki page on concatenating files</a>.</p>
       <p class="link"></p>
     </div>
-    <!-- ends Join files together -->
+    <!-- ends Join files of the same type together -->
+
+    <!-- Join files of different types together -->
+    <label class="recipe" for="join_different_files">Join (concatenate) two or more files of different types</label>
+     <input type="checkbox" id="join_different_files">
+     <div class="hiding">
+       <h3>Join files together</h3>
+      <!-- ffmpeg -i input1.mov -i input2.avi -filter_complex "[0:v:0][0:a:0][1:v:0][1:a:0]concat=n=2:v=1:a=1[outv][outa]" -map "[outv]" -map "[outa]" output.mkv -->
+      <p><code>ffmpeg -i input1.avi -i input2.mp4 -filter_complex "[0:v:0][0:a:0][1:v:0][1:a:0]concat=n=2:v=1:a=1[videoOut][audioOut]" -map "[videoOut]" -map "[audioOut]" <i>output_file</i></code></p>
+      <p>
+        This command takes two or more files of the different file types and joins them together to make a single file.<br>
+        However, it only works properly if the files to be combined have the same dimensions (e.g., 720x576). Some aspects of the input files will be normalised: for example, if an input file contains a video track and an audio track that do not have exactly the same duration, the shorter one will be padded. However, note that if the input files have different framerates, the output file will be of variable framerate.
+      </p>
+      <dl>
+        <dt>ffmpeg</dt><dd>starts the command</dd>
+        <dt>-i <i>input1.ext</i></dt><dd>path, name and extension of the first input file</dd>
+        <dt>-i <i>input2.ext</i></dt><dd>path, name and extension of the second input file</dd>
+        <dt>-filter_complex</dt><dd>starts the complex filtergraph</dd>
+        <dt>"</dt><dd>quotation mark to start filtergraph</dd>
+        <dt>[0:v:0][0:a:0]</dt><dd>selects the first video stream and first audio stream from the first input.<br>
+          References to different streams are each enclosed in square brackets. In the first stream reference, <code>0:v:0</code>, the first zero refers to the first input file, <code>v</code> means video stream, and the second zero indicates that it is the <i>first</i> video stream in the file that should be selected. Likewise, <code>0:a:0</code> means the first audio stream in the first input file.<br>
+          As demonstrated above, ffmpeg uses zero-indexing: <code>0</code> means the first input/stream/etc, <code>1</code> means the second input/stream/etc, and <code>4</code> would mean the fifth input/stream/etc.</dd>
+        <dt>[1:v:0][1:a:0]</dt><dd>As described above, this means select the first video and audio streams from the second input file.</dd>
+        <dt>concat=</dt><dd>starts the <code>concat</code> filter</dd>
+        <dt>n=2</dt><dd>states that there are two input files</dd>
+        <dt>:</dt><dd>separator</dd>
+        <dt>v=1</dt><dd>sets the number of output video streams.<br>
+          Note that this must be equal to the number of video streams selected from each segment.</dd>
+        <dt>:</dt><dd>separator</dd>
+        <dt>a=1</dt><dd>sets the number of output audio streams.<br>
+          Note that this must be equal to the number of audio streams selected from each segment.</dd>
+        <dt>[videoOut]</dt><dd>name of the concatenated output video stream. This is a variable name which you define, so you could call it something different, like “vOut”, “outv”, or “banana”.</dd>
+        <dt>[audioOut]</dt><dd>name of the concatenated output audio stream. Again, this is a variable name which you define.</dd>
+        <dt>"</dt><dd>quotation mark to end filtergraph</dd>
+        <dt>-map "[videoOut]"</dt><dd>map the concatenated video stream into the output file by referencing the variable defined above</dd>
+        <dt>-map "[audioOut]"</dt><dd>map the concatenated audio stream into the output file by referencing the variable defined above</dd>
+        <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
+      </dl>
+      <p>For more information, see the <a href="https://trac.ffmpeg.org/wiki/Concatenate#differentcodec" target="_blank">FFmpeg wiki page on concatenating files of different types</a>.</p>
+      <p class="link"></p>
+    </div>
+    <!-- ends Join files of the different types together -->
+
 
     <!-- Split file into segments -->
     <label class="recipe" for="segment_file">Split one file into several smaller segments</label>

--- a/index.html
+++ b/index.html
@@ -945,6 +945,17 @@
         <dt>-map "[audioOut]"</dt><dd>map the concatenated audio stream into the output file by referencing the variable defined above</dd>
         <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
       </dl>
+      <p>
+        To specify the characteristics of the output stream(s), add flags after the <code>-map "[out]"</code> part of the command.
+      </p>
+      <p>
+        For example, to ensure that the video stream of the output file is visually lossless H.264 with a 4:2:0 chroma subsampling scheme, the command above could be amended to include the following:<br>
+        <code>-map "[videoOut]" -c:v libx264 -pix_fmt yuv420p -preset veryslow -crf 18</code>
+      </p>
+      <p>
+        Likewise, to encode the output audio stream as mp3, the command could include the following:<br>
+        <code>-map "[audioOut]" -c:a libmp3lame -dither_method modified_e_weighted -qscale:a 2</code><br>
+      </p>
       <p>For more information, see the <a href="https://trac.ffmpeg.org/wiki/Concatenate#differentcodec" target="_blank">FFmpeg wiki page on concatenating files of different types</a>.</p>
       <p class="link"></p>
     </div>

--- a/index.html
+++ b/index.html
@@ -915,10 +915,8 @@
      <div class="hiding">
       <h3>Join files together</h3>
       <p><code>ffmpeg -i input1.avi -i input2.mp4 -filter_complex "[0:v:0][0:a:0][1:v:0][1:a:0]concat=n=2:v=1:a=1[videoOut][audioOut]" -map "[videoOut]" -map "[audioOut]" <i>output_file</i></code></p>
-      <p>
-        This command takes two or more files of the different file types and joins them together to make a single file.<br>
-        However, it only works properly if the files to be combined have the same dimensions (e.g., 720x576). Some aspects of the input files will be normalised: for example, if an input file contains a video track and an audio track that do not have exactly the same duration, the shorter one will be padded. However, note that if the input files have different framerates, the output file will be of variable framerate.
-      </p>
+      <p>This command takes two or more files of the different file types and joins them together to make a single file.<br>
+      However, it only works properly if the files to be combined have the same dimensions (e.g., 720x576). Some aspects of the input files will be normalised: for example, if an input file contains a video track and an audio track that do not have exactly the same duration, the shorter one will be padded. However, note that if the input files have different framerates, the output file will be of variable framerate.</p>
       <dl>
         <dt>ffmpeg</dt><dd>starts the command</dd>
         <dt>-i <i>input1.ext</i></dt><dd>path, name and extension of the first input file</dd>
@@ -944,17 +942,11 @@
         <dt>-map "[audioOut]"</dt><dd>map the concatenated audio stream into the output file by referencing the variable defined above</dd>
         <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
       </dl>
-      <p>
-        To specify the characteristics of the output stream(s), add flags after the <code>-map "[out]"</code> part of the command.
-      </p>
-      <p>
-        For example, to ensure that the video stream of the output file is visually lossless H.264 with a 4:2:0 chroma subsampling scheme, the command above could be amended to include the following:<br>
-        <code>-map "[videoOut]" -c:v libx264 -pix_fmt yuv420p -preset veryslow -crf 18</code>
-      </p>
-      <p>
-        Likewise, to encode the output audio stream as mp3, the command could include the following:<br>
-        <code>-map "[audioOut]" -c:a libmp3lame -dither_method modified_e_weighted -qscale:a 2</code><br>
-      </p>
+      <p>To specify the characteristics of the output stream(s), add flags after the <code>-map "[out]"</code> part of the command.</p>
+      <p>For example, to ensure that the video stream of the output file is visually lossless H.264 with a 4:2:0 chroma subsampling scheme, the command above could be amended to include the following:<br>
+        <code>-map "[videoOut]" -c:v libx264 -pix_fmt yuv420p -preset veryslow -crf 18</code></p>
+      <p>Likewise, to encode the output audio stream as mp3, the command could include the following:<br>
+        <code>-map "[audioOut]" -c:a libmp3lame -dither_method modified_e_weighted -qscale:a 2</code></p>
       <p>For more information, see the <a href="https://trac.ffmpeg.org/wiki/Concatenate#differentcodec" target="_blank">FFmpeg wiki page on concatenating files of different types</a>.</p>
       <p class="link"></p>
     </div>

--- a/index.html
+++ b/index.html
@@ -915,8 +915,10 @@
      <div class="hiding">
       <h3>Join files together</h3>
       <p><code>ffmpeg -i input1.avi -i input2.mp4 -filter_complex "[0:v:0][0:a:0][1:v:0][1:a:0]concat=n=2:v=1:a=1[videoOut][audioOut]" -map "[videoOut]" -map "[audioOut]" <i>output_file</i></code></p>
-      <p>This command takes two or more files of the different file types and joins them together to make a single file.<br>
-      However, it only works properly if the files to be combined have the same dimensions (e.g., 720x576). Some aspects of the input files will be normalised: for example, if an input file contains a video track and an audio track that do not have exactly the same duration, the shorter one will be padded. However, note that if the input files have different framerates, the output file will be of variable framerate.</p>
+      <p>This command takes two or more files of the different file types and joins them together to make a single file.</p>
+      <p>However, it only works properly if the files to be combined have the same dimensions (e.g., 720x576).</p>
+      <p>Some aspects of the input files will be normalised: for example, if an input file contains a video track and an audio track that do not have exactly the same duration, the shorter one will be padded. In the case of a shorter video track, the last frame will be repeated in order to cover the missing video; in the case of a shorter audio track, the audio stream will be padded with silence.</p>
+      <p>Note that if the input files have different framerates, the output file will be of variable framerate.</p>
       <dl>
         <dt>ffmpeg</dt><dd>starts the command</dd>
         <dt>-i <i>input1.ext</i></dt><dd>path, name and extension of the first input file</dd>
@@ -942,7 +944,7 @@
         <dt>-map "[audioOut]"</dt><dd>map the concatenated audio stream into the output file by referencing the variable defined above</dd>
         <dt><i>output_file</i></dt><dd>path, name and extension of the output file</dd>
       </dl>
-      <p>To specify the characteristics of the output stream(s), add flags after the <code>-map "[out]"</code> part of the command.</p>
+      <p>If no characteristics of the output files are specified, ffmpeg will use the default encodings associated with the given output file type. To specify the characteristics of the output stream(s), add flags after each <code>-map "[out]"</code> part of the command.</p>
       <p>For example, to ensure that the video stream of the output file is visually lossless H.264 with a 4:2:0 chroma subsampling scheme, the command above could be amended to include the following:<br>
         <code>-map "[videoOut]" -c:v libx264 -pix_fmt yuv420p -preset veryslow -crf 18</code></p>
       <p>Likewise, to encode the output audio stream as mp3, the command could include the following:<br>

--- a/index.html
+++ b/index.html
@@ -1038,6 +1038,7 @@
         <dt>ffmpeg</dt><dd>starts the command</dd>
         <dt>-i <i>input_file</i></dt><dd>path, name and extension of the input file</dd>
         <dt>-c:v libx264</dt><dd>encodes video stream with libx264 (h264)</dd>
+        <dt>-filter:v</dt><dd>a video filter will be used</dd>
         <dt>"</dt><dd>quotation mark to start filtergraph</dd>
         <dt>yadif</dt><dd>deinterlacing filter (‘yet another deinterlacing filter’)<br>
          By default, <a href="https://ffmpeg.org/ffmpeg-filters.html#yadif-1" target="_blank">yadif</a> will output one frame for each frame. Outputting one frame for each <i>field</i> (thereby doubling the frame rate) with <code>yadif=1</code> may produce visually better results.</dd>


### PR DESCRIPTION
I was thinking about #292 today, and decided to look into the `concat` filter some more. Here I've added a recipe for concatenating input files of different types.

Questions/issues:
- Wording may need some love ... feel free to nitpick
- I'm getting the desired results, but if someone else can test the command(s), that would be super
- ~If you don't specify the specs for the output streams, as described in the second part of the entry, it's pretty unclear to me how ffmpeg 'decides' what the output specs will be - the [docs](https://ffmpeg.org/ffmpeg-filters.html#concat) aren't very clear on this point. (Actually, I find the concat docs confusingly worded in general).~ Lol I'm an idiot, see below. Though I still think the concat docs could be better worded just generally.
  - I've asked about this on the ffmpeg-user listserv ([link](http://ffmpeg.org/pipermail/ffmpeg-user/2018-January/038698.html)), hopefully someone there will have some more info.
  - Update: Ugh, this is what happens when you look at this stuff as insomniac. The default output specs are just those of the output file type - DUH. I don't know why I thought some extra \~magic\~ was going on there, but I got that idea in my head. Now my embarrassing misunderstanding complete with multiple typos is immortalised on the ffmpeg-user, great job Katherine.
- This recipe, though already lengthy, could be expanded. For example, it would be good to include a command for inputs of different resolution, e.g. using a scale filter prior to concatenation.

Also, a couple of little fixes elsewhere:
- add `-c:a aac` to the H.264/MP4 recipes. Since AAC and MP4 are birds of a feather, I think that's more sensible than having `-c:a copy`.
- add a missing line to a recipe explanation