### PR TITLE
removes calls to google fonts CDN

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -1,6 +1,6 @@
 html, body {
   line-height: 1.5;
-  font-size: 16px;
+  font-size: 18px;
   color: #888888;
   background-color: #060606;
   margin: 0;
@@ -89,7 +89,7 @@ a:visited {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'Montserrat', sans-serif;
+  font-family: sans-serif;
 }
 
 h1 {
@@ -116,7 +116,7 @@ h4 {
 }
 
 .intro-lead {
-  font-family: 'Montserrat', sans-serif;
+  font-family: sans-serif;
   font-size: 1em;
 }
 
@@ -165,7 +165,7 @@ img {
 }
 
 div {
-  font-family: 'Merriweather', serif;
+  font-family: sans-serif;
   color: white;
 }
 
@@ -177,7 +177,6 @@ div {
   color: white;
   background-color: #383838;
   padding: 14px;
-  font-family: "Montserrat";
   letter-spacing: 0.05em;
   border: 1px solid black;
   cursor: pointer;

--- a/css/css.css
+++ b/css/css.css
@@ -1,6 +1,7 @@
 html, body {
   line-height: 1.5;
   font-size: 18px;
+  font-family: sans-serif;
   color: #888888;
   background-color: #060606;
   margin: 0;
@@ -88,9 +89,6 @@ a:visited {
   display: inline;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: sans-serif;
-}
 
 h1 {
   letter-spacing: 0.1em;
@@ -116,7 +114,6 @@ h4 {
 }
 
 .intro-lead {
-  font-family: sans-serif;
   font-size: 1em;
 }
 
@@ -165,7 +162,6 @@ img {
 }
 
 div {
-  font-family: sans-serif;
   color: white;
 }
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <head>
   <title>ffmprovisr</title>
   <meta name="viewport" charset="utf-8" content="text/html, width=device-width, initial-scale=1">
-  <!-- <link href="https://fonts.googleapis.com/css?family=Montserrat%7CMerriweather" rel="stylesheet" type="text/css"> -->
   <link rel="stylesheet" href="css/css.css">
   <link rel="icon" href="img/vhs.ico">
   <script src="js/jquery.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>ffmprovisr</title>
   <meta name="viewport" charset="utf-8" content="text/html, width=device-width, initial-scale=1">
-  <link href="https://fonts.googleapis.com/css?family=Montserrat%7CMerriweather" rel="stylesheet" type="text/css">
+  <!-- <link href="https://fonts.googleapis.com/css?family=Montserrat%7CMerriweather" rel="stylesheet" type="text/css"> -->
   <link rel="stylesheet" href="css/css.css">
   <link rel="icon" href="img/vhs.ico">
   <script src="js/jquery.min.js"></script>


### PR DESCRIPTION
Up for discussion, but I find that the short lag it takes to load and render fonts from the Google CDN when running ffmprovisr locally to be really annoying. Removing it will make the website marginally faster and look identical offline and online, and not throw errors when offline.