### PR TITLE
Revert "Adds mapping all audio to access script"

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@
     <input type="checkbox" id="transcode_h264">
     <div class="hiding">
       <h3>Transcode to H.264</h3>
-      <p><code>ffmpeg -i <em>input_file</em> -c:v libx264 -pix_fmt yuv420p -c:a aac -map 0:a <em>output_file</em></code></p>
+      <p><code>ffmpeg -i <em>input_file</em> -c:v libx264 -pix_fmt yuv420p -c:a aac <em>output_file</em></code></p>
       <p>This command takes an input file and transcodes it to H.264 with an .mp4 wrapper, audio is transcoded to AAC. The libx264 codec defaults to a “medium” preset for compression quality and a CRF of 23. CRF stands for constant rate factor and determines the quality and file size of the resulting H.264 video. A low CRF means high quality and large file size; a high CRF means the opposite.</p>
       <dl>
         <dt>ffmpeg</dt><dd>starts the command</dd>
@@ -303,7 +303,6 @@
         <dt>-pix_fmt yuv420p</dt><dd>libx264 will use a chroma subsampling scheme that is the closest match to that of the input. This can result in Y′C<sub>B</sub>C<sub>R</sub> 4:2:0, 4:2:2, or 4:4:4 chroma subsampling. QuickTime and most other non-FFmpeg based players can’t decode H.264 files that are not 4:2:0. In order to allow the video to play in all players, you can specify 4:2:0 chroma subsampling.</dd>
         <dt>-c:a aac</dt><dd>encode audio as AAC.<br>
           AAC is the codec most often used for audio streams within an .mp4 container.</dd>
-        <dt>-map 0:a</dt><dd>maps all audio tracks (default is first two)</dd>
         <dt><em>output_file</em></dt><dd>path, name and extension of the output file</dd>
       </dl>
       <p>In order to optimize the file for streaming, you can add this preset:</p>


### PR DESCRIPTION
Reverts amiaopensource/ffmprovisr#387.

I have been testing this script and I don't think it's quite good enough to be recommended. The `map` feature is too broad and it can accidentally create files with only audio. This works for some use cases but not broadly enough to be a good solution for all users.

It'd be nice to spend more time sorting this out but I have other responsibilities.