### PR TITLE
add all containers for ProRes

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
     <input type="checkbox" id="to_prores">
     <div class="hiding">
       <h5>Transcode into a deinterlaced Apple ProRes LT</h5>
-      <p><code>ffmpeg -i <em>input_file</em> -c:v prores -profile:v 1 -vf yadif -c:a pcm_s16le <em>output_file</em>.mov</code></p>
+      <p><code>ffmpeg -i <em>input_file</em> -c:v prores -profile:v 1 -vf yadif -c:a pcm_s16le <em>output_file</em></code></p>
       <p>This command transcodes an input file into a deinterlaced Apple ProRes 422 LT file with 16-bit linear PCM encoded audio. The file is deinterlaced using the yadif filter (Yet Another De-Interlacing Filter).</p>
       <dl>
         <dt>ffmpeg</dt><dd>starts the command</dd>
@@ -292,7 +292,7 @@
         <dt>-vf yadif</dt><dd>Runs a deinterlacing video filter (yet another deinterlacing filter) on the new file. <code>-vf</code> is an alias for <code>-filter:v</code>.</dd>
         <dt>-c:a pcm_s16le</dt><dd>tells FFmpeg to encode the audio stream in 16-bit linear PCM</dd>
         <dt><em>output_file</em></dt><dd>path, name and extension of the output file<br>
-        The extension for the QuickTime container is <code>.mov</code>.</dd>
+        There are currently three possible containers for ProRes 422 and 4444 which are all supported by FFmpeg: QuickTime (<code>.mov</code>), Matroska (<code>.mkv</code>) and Material eXchange Format (<code>.mxf</code>).</dd>
       </dl>
       <p>FFmpeg comes with more than one ProRes encoder:</p>
       <ul>


### PR DESCRIPTION
FFmpeg supports three containers for the various ProRes 422 and ProRes 4444 flavours: 
- QuickTime (`.mov`)
- Matroska (`.mkv`)
- Material eXchange Format (`.mxf`)