### PR TITLE
update H.265/HEVC formula

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,7 +432,6 @@
       <h5>Transcode to H.265/HEVC</h5>
       <p><code>ffmpeg -i <em>input_file</em> -c:v libx265 -pix_fmt yuv420p -c:a copy <em>output_file</em></code></p>
       <p>This command takes an input file and transcodes it to H.265/HEVC in an .mp4 wrapper, keeping the audio codec the same as in the original file.</p>
-      <p><strong>Note:</strong> FFmpeg must be compiled with libx265, the library of the H.265 codec, for this script to work. (Add the flag <code>--with-x265</code> if using the <code>brew install ffmpeg</code> method).</p>
       <dl>
         <dt>ffmpeg</dt><dd>starts the command</dd>
         <dt>-i <em>input file</em></dt><dd>path, name and extension of the input file</dd>


### PR DESCRIPTION
## Checklist

* [x] I've referred to the [Guidelines for contributing](https://github.com/amiaopensource/ffmprovisr/blob/gh-pages/readme.md#guidelines-for-contributing)

The option `--with-x265` is now enabled on the [standard Homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ffmpeg.rb) formula, as well as on the alternate ones: [homebrew-ffmpeg](https://github.com/homebrew-ffmpeg/homebrew-ffmpeg/blob/master/Formula/ffmpeg.rb) and [AVpres](https://github.com/AVpres/homebrew-formulae/blob/master/ffmpeg.rb).