### PR TITLE
update QEMU QED link

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
       <p><a href="https://datapraxis.github.io/sourcecaster/" target="_blank">The Sourcecaster</a>: an app that helps you use the command line to work through common challenges that come up when working with digital primary sources.</p>
       <p><a href="https://pugetsoundandvision.github.io/micropops/" target="_blank">Micropops</a>: One liners and automation tools from Moving Image Preservation of Puget Sound</p>
       <p><a href="https://amiaopensource.github.io/cable-bible/" target="_blank">Cable Bible</a>: A Guide to Cables and Connectors Used for Audiovisual Tech</p>
-      <p><a href="https://eaasi.gitlab.io/qemu-qed/" target="_blank">QEMU QED</a>: instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization</p>
+      <p><a href="https://eaasi.gitlab.io/program_docs/qemu-qed/" target="_blank">QEMU QED</a>: instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization</p>
       <p><a href="https://amiaopensource.github.io/ffmpeg-artschool/" target="_blank">ffmpeg-artschool</a>: An AMIA workshop featuring scripts, exercises, and activities to make art using FFmpeg</p>
     </div>
 


### PR DESCRIPTION
fixed to the correct GitLab Pages link

## Checklist

* [x] I've referred to the [Guidelines for contributing](https://github.com/amiaopensource/ffmprovisr/blob/gh-pages/readme.md#guidelines-for-contributing)
