### PR TITLE
don't try to find the default browser on macOS

### DIFF
--- a/scripts/ffmprovisr
+++ b/scripts/ffmprovisr
@@ -4,17 +4,12 @@
 # connected to the Web, and the local version otherwise.
 
 if [[ "$(uname -s)" = "Darwin" ]] ; then
-    default_browser=$(plutil -convert json ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist -r -o - | grep https -b1 | tail -n1 | cut -d'"' -f4)
     if ping -c 1 amiaopensource.github.io >/dev/null 2>&1 ; then
         ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'
     else
         ffmprovisr_path=$(find /usr/local/Cellar/ffmprovisr -iname 'index.html' | sort -M | tail -n1)
     fi
-    if [[ -n "${default_browser}" ]] ; then
-        open -b "${default_browser}" "${ffmprovisr_path}"
-    else
-        open "${ffmprovisr_path}"
-    fi
+    open "${ffmprovisr_path}"
 elif [[ "$(uname -s)" = "Linux" ]] ; then
     if ping -c 1 amiaopensource.github.io >/dev/null 2>&1 ; then
         ffmprovisr_path='https://amiaopensource.github.io/ffmprovisr/'


### PR DESCRIPTION
## Checklist

* [x] I've referred to the [Guidelines for contributing](https://github.com/amiaopensource/ffmprovisr/blob/gh-pages/readme.md#guidelines-for-contributing)

I’m sorry, I forgot that we have the same issue here as with Cable Bible: the default browser can not longer be found that way and therefore the command `ffmprovisr` gives an error message on macOS Big Sur. This is the same radical fix as used for Cable Bible.