### PR TITLE
Fix indentation of code block showing file contents

### DIFF
--- a/index.html
+++ b/index.html
@@ -1098,10 +1098,12 @@
         <dt>-f concat</dt><dd>forces ffmpeg to concatenate the files and to keep the same file format</dd>
         <dt>-i <em>mylist.txt</em></dt><dd>path, name and extension of the input file. Per the <a href="https://ffmpeg.org/ffmpeg-formats.html#Options" target="_blank">FFmpeg documentation</a>, it is preferable to specify relative rather than absolute file paths, as allowing absolute file paths may pose a security risk.<br>
         This text file contains the list of files to be concatenated and should be formatted as follows:
-        <pre>file '<em>./first_file.ext</em>'
+<pre>
+  file '<em>./first_file.ext</em>'
   file '<em>./second_file.ext</em>'
   . . .
-  file '<em>./last_file.ext</em>'</pre>
+  file '<em>./last_file.ext</em>'
+</pre>
   In the above, <strong>file</strong> is simply the word "file". Straight apostrophes ('like this') rather than curved quotation marks (‘like this’) must be used to enclose the file paths.<br>
   <strong>Note:</strong> If specifying absolute file paths in the .txt file, add <code>-safe 0</code> before the input file.<br>
   e.g.: <code>ffmpeg -f concat -safe 0 -i mylist.txt -c copy <em>output_file</em></code></dd>


### PR DESCRIPTION
Previously, the second and following lines were indented compared to the first line.

Noticed when looking into the [issue](https://github.com/amiaopensource/ffmprovisr/issues/457) that @brainwane reported!

Before & after:

![before](https://user-images.githubusercontent.com/16832997/167708501-33275ae2-e70a-4195-ad9b-1755b65c756b.png)

![after](https://user-images.githubusercontent.com/16832997/167708539-b8dcdcf1-c102-45b5-8fe0-848b2dce1af8.png)

