### PR TITLE
delete `get_recipe_list` script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,8 +53,6 @@ ffmpeg command n-1
 ffmpeg command n
 ```
 
-The used [one-liner](scripts/get_recipe_list) is in the `scripts` folder.
-
 ## How do I contribute?
 
 You are welcome to edit the codebase yourself, or just supply the information and ask it to be added to the site.

--- a/scripts/get_recipe_list
+++ b/scripts/get_recipe_list
@@ -1,1 +1,0 @@
-curl https://amiaopensource.github.io/ffmprovisr/ -s | grep -E '<h5>.*</h5>|<p><code>.*</code></p>' | sed 's/.*<code>\(.*\)<\/code>/\1/' | sed 's/.*<h5>\(.*\)<\/h5>/# \1/' | grep -v '\*\*\*' | sed -e 's/<[^>]*>//g'


### PR DESCRIPTION
My script does not longer work as desired. I guess, it’s today simpler to update the command list manually. In addition, the command list was used mainly by `FFCommand_Engine`, which is no longer maintained.

## Checklist

* [x] I've referred to the [Guidelines for contributing](https://github.com/amiaopensource/ffmprovisr/blob/gh-pages/readme.md#guidelines-for-contributing)
