### PR TITLE
Addition of MIAP-ZIM-Project hyperlink to the "Sister Projects" header.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ Last updated: 2019-12-11
 [The Cable Bible](https://amiaopensource.github.io/cable-bible/): A Guide to Cables and Connectors Used for Audiovisual Tech  
 [FFCommand_Engine](https://github.com/ColorlabMD/FFCommand_Engine): a tool for easier use of FFmpeg binaries  
 [QEMU QED](https://eaasi.gitlab.io/program_docs/qemu-qed/): instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization                 
-[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim)
+[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim)                                                                                                                                                                                     
 [Script Ahoy](http://dd388.github.io/crals/): Community Resource for Archivists and Librarians Scripting  
 [sourcecaster](https://datapraxis.github.io/sourcecaster/): helps you use the command line to work through common challenges that come up when working with digital primary sources. 
                                        

--- a/readme.md
+++ b/readme.md
@@ -171,8 +171,8 @@ Last updated: 2019-12-11
 
 [The Cable Bible](https://amiaopensource.github.io/cable-bible/): A Guide to Cables and Connectors Used for Audiovisual Tech  
 [FFCommand_Engine](https://github.com/ColorlabMD/FFCommand_Engine): a tool for easier use of FFmpeg binaries  
-[QEMU QED](https://eaasi.gitlab.io/program_docs/qemu-qed/): instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization                 
-[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim)                                                                                                                                                                                     
+[QEMU QED](https://eaasi.gitlab.io/program_docs/qemu-qed/): instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization
+[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim)                                       
 [Script Ahoy](http://dd388.github.io/crals/): Community Resource for Archivists and Librarians Scripting  
 [sourcecaster](https://datapraxis.github.io/sourcecaster/): helps you use the command line to work through common challenges that come up when working with digital primary sources. 
                                        

--- a/readme.md
+++ b/readme.md
@@ -172,10 +172,10 @@ Last updated: 2019-12-11
 [The Cable Bible](https://amiaopensource.github.io/cable-bible/): A Guide to Cables and Connectors Used for Audiovisual Tech  
 [FFCommand_Engine](https://github.com/ColorlabMD/FFCommand_Engine): a tool for easier use of FFmpeg binaries  
 [QEMU QED](https://eaasi.gitlab.io/program_docs/qemu-qed/): instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization
-[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim)                                       
-[Script Ahoy](http://dd388.github.io/crals/): Community Resource for Archivists and Librarians Scripting  
-[sourcecaster](https://datapraxis.github.io/sourcecaster/): helps you use the command line to work through common challenges that come up when working with digital primary sources. 
-                                       
+[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim)
+[Script Ahoy](http://dd388.github.io/crals/): Community Resource for Archivists and Librarians Scripting
+[sourcecaster](https://datapraxis.github.io/sourcecaster/): helps you use the command line to work through common challenges that come up when working with digital primary sources.
+
 ## Articles and mentions
 
 * 2019-09: **Andrew Weaver & Ashley Blewer**, [Sustainability through community: ffmprovisr and the Case for Collaborative Knowledge Transfer](https://ipres2019.org/static/pdf/iPres2019_paper_97.pdf) (PDF), iPRES 2019

--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ Last updated: 2019-12-11
 [The Cable Bible](https://amiaopensource.github.io/cable-bible/): A Guide to Cables and Connectors Used for Audiovisual Tech  
 [FFCommand_Engine](https://github.com/ColorlabMD/FFCommand_Engine): a tool for easier use of FFmpeg binaries  
 [QEMU QED](https://eaasi.gitlab.io/program_docs/qemu-qed/): instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization                 
-[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim) 
+[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim)
 [Script Ahoy](http://dd388.github.io/crals/): Community Resource for Archivists and Librarians Scripting  
 [sourcecaster](https://datapraxis.github.io/sourcecaster/): helps you use the command line to work through common challenges that come up when working with digital primary sources. 
                                        

--- a/readme.md
+++ b/readme.md
@@ -171,10 +171,11 @@ Last updated: 2019-12-11
 
 [The Cable Bible](https://amiaopensource.github.io/cable-bible/): A Guide to Cables and Connectors Used for Audiovisual Tech  
 [FFCommand_Engine](https://github.com/ColorlabMD/FFCommand_Engine): a tool for easier use of FFmpeg binaries  
-[QEMU QED](https://eaasi.gitlab.io/program_docs/qemu-qed/): instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization  
+[QEMU QED](https://eaasi.gitlab.io/program_docs/qemu-qed/): instructions for using QEMU (Quick EMUlator), a command line application for computer emulation and virtualization                 
+[MIAP-ZIM-Project](https://github.com/hmr9162-droid/MIAP-ZIM-Project/): motion image archiving tools made available as offline accesible .zim files (including ffmprovisr.zim and cable-bible.zim) 
 [Script Ahoy](http://dd388.github.io/crals/): Community Resource for Archivists and Librarians Scripting  
-[sourcecaster](https://datapraxis.github.io/sourcecaster/): helps you use the command line to work through common challenges that come up when working with digital primary sources.
-
+[sourcecaster](https://datapraxis.github.io/sourcecaster/): helps you use the command line to work through common challenges that come up when working with digital primary sources. 
+                                       
 ## Articles and mentions
 
 * 2019-09: **Andrew Weaver & Ashley Blewer**, [Sustainability through community: ffmprovisr and the Case for Collaborative Knowledge Transfer](https://ipres2019.org/static/pdf/iPres2019_paper_97.pdf) (PDF), iPRES 2019


### PR DESCRIPTION

Addition of MIAP-ZIM-Project hyperlink to the "Sister Projects" header in the README.

This project uses ffmprovisr and cable-bible as a reverent for the assessment of ZIM and WARC web archiving formats. We hope to archive other motion image archiving resources as .zim in the future for use in remote locations or sites without internet. We've mirrored the existing format, and listed the project according to alphabetized order. We've made no actual code-contributions to ffmprovisr.

## Checklist
* [x] I've referred to the [Guidelines for contributing](https://github.com/amiaopensource/ffmprovisr/blob/gh-pages/readme.md#guidelines-for-contributing) 
